### PR TITLE
Updated c++ api

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ test-c: release
 	target/ctest
 
 test-cpp: release
-	g++ $(CFLAGS) -std=c++11 tests/test.cpp -o target/cpptest -lc2pa_c -L./target/release 
+	g++ $(CFLAGS) -std=c++17 tests/test.cpp -o target/cpptest -lc2pa_c -L./target/release 
 	target/cpptest
 
 example: release

--- a/README.md
+++ b/README.md
@@ -26,7 +26,11 @@ Use the `read_file` function to read C2PA data from the specified file:
 auto json_store = C2pa::read_file("path/to/media_file.jpg", "path/to/data_dir")
 ```
 
-This function examines the specified media file for C2PA data and generates a JSON report of any data it finds. If there are validation errors, the report includes a `validation_status` field.  For a summary of supported media types, see [Supported file formats](#supported-file-formats).
+This function examines the specified media file for C2PA data and generates a JSON report conditionally if it finds c2pa data.
+
+Exceptions will be thrown on errors.
+
+If there are validation errors, the report includes a `validation_status` field.  For a summary of supported media types, see [Supported file formats](#supported-file-formats).
 
 A media file may contain many manifests in a manifest store. The most recent manifest is identified by the value of the `active_manifest` field in the manifests map.
 
@@ -46,7 +50,7 @@ string private_key = read_text_file("path/to/private.key").data();
 Then create a new `SignerInfo` instance using the keys as follows, specifying the signing algorithm used and optionally a time stamp authority URL:
 
 ```c++
-C2paSignerInfo sign_info = {.alg = "es256",  .sign_cert = certs.c_str(), .private_key = private_key.c_str(), .ta_url = "http://timestamp.digicert.com"};
+C2pa::SignerInfo sign_info = {.alg = "es256",  .sign_cert = certs.c_str(), .private_key = private_key.c_str(), .ta_url = "http://timestamp.digicert.com"};
 ```
 
 For the list of supported signing algorithms, see [Creating and using an X.509 certificate](https://opensource.contentauthenticity.org/docs/c2patool/x_509).
@@ -87,12 +91,11 @@ const std::string manifest_json = R"{
 Use the `sign_file` function to add a signed manifest to a media file.
 
 ```c++
-result = C2pa::sign_file("path/to/source.jpg", 
-                         "path/to/dest.jpg",
-                         manifest_json.c_str(),
-                         sign_info,
-                         "path/to/data_dir);
-                          "target/example/training.jpg", manifest_json.c_str(), sign_info, NULL);
+C2pa::sign_file("path/to/source.jpg", 
+                    "path/to/dest.jpg",
+                    manifest_json.c_str(),
+                    &sign_info,
+                    "path/to/data_dir);
 
 ```
 
@@ -102,6 +105,8 @@ The parameters (in order) are:
 - `manifest_json`, a JSON-formatted string containing the manifest data you want to add; see [Creating a manifest JSON definition file](#creating-a-manifest-json-definition-file) below.
 - `sign_info`, a `SignerInfo` object instance; see [Generating SignerInfo](#generating-signerinfo) below.
 - `data_dir` optionally specifies a directory path from which to load resource files referenced in the manifest JSON identifier fields; for example, thumbnails, icons, and manifest data for ingredients.
+
+Exceptions will be thrown on errors.
 
 See [training.cpp](https://github.com/contentauth/c2pa-c/blob/main/examples/training.py) for an example.
 

--- a/examples/training.cpp
+++ b/examples/training.cpp
@@ -51,16 +51,16 @@ int main()
         C2pa::SignerInfo sign_info = {.alg = "es256", .sign_cert = certs.c_str(), .private_key = private_key.c_str(), .ta_url = "http://timestamp.digicert.com"};
 
         // sign the file
-        C2pa::sign_file("tests/fixtures/A.jpg", "target/example/training.jpg", manifest_json.c_str(), sign_info);
+        C2pa::sign_file("tests/fixtures/A.jpg", "target/example/training.jpg", manifest_json.c_str(), &sign_info);
 
         // read the new manifest and display the JSON
         auto new_manifest_json = C2pa::read_file("target/example/training.jpg");
-        cout << "The new manifest is " << new_manifest_json << endl;
+        cout << "The new manifest is " << new_manifest_json.value() << endl;
 
         // parse the manifest and display the AI training status
 
         bool allowed = true; // default to allowed
-        json manifest_store = json::parse(new_manifest_json.c_str());
+        json manifest_store = json::parse(new_manifest_json.value());
 
         // get the active manifest
         string active_manifest = manifest_store["active_manifest"];

--- a/include/c2pa.h
+++ b/include/c2pa.h
@@ -131,7 +131,7 @@ IMPORT extern
 char *c2pa_sign_file(const char *source_path,
                      const char *dest_path,
                      const char *manifest,
-                     struct C2paSignerInfo signer_info,
+                     const struct C2paSignerInfo *signer_info,
                      const char *data_dir);
 
 /**

--- a/include/c2pa.hpp
+++ b/include/c2pa.hpp
@@ -11,7 +11,10 @@
 // each license.
 
 #include <iostream>
+#include <string.h>
 #include "c2pa.h"
+#include <filesystem> 
+using namespace std::__fs::filesystem;
 
 namespace C2pa
 {
@@ -19,121 +22,96 @@ namespace C2pa
 
     typedef C2paSignerInfo SignerInfo;
 
-    // C++ wrapper for Rust strings with destructor to release memory
-    class String
-    {
-    private:
-        char *str;
-
-        // This should only be called by the C2pa library with Rust Strings
-        String(char *rust_str)
-        {
-            str = rust_str;
-        }
-
-        // These functions are friends of the String class so they can access the private constructor
-        friend String version();
-        friend String read_file(const char *filename, const char *data_dir);
-        friend String read_ingredient_file(const char *filename, const char *data_dir);
-        friend String sign_file(const char *source_path,
-                                const char *dest_path,
-                                const char *manifest,
-                                struct C2paSignerInfo signer_info,
-                                const char *data_dir);
-
-    public:
-        ~String()
-        {
-            c2pa_release_string(str);
-        }
-
-        char *c_str() const
-        {
-            return str;
-        }
-        string toString() const
-        {
-            return string((*this).str);
-        }
-        friend ostream &operator<<(ostream &os, const String &s)
-        {
-            os << s.str;
-            return os;
-        }
-    };
-
     // Exception class for C2pa errors
     class Exception : public exception
     {
     private:
-        char *message;
+        string message;
 
     public:
-        Exception() : message(c2pa_error()) {}
+        Exception() : message(c2pa_error()) {
+            auto result = c2pa_error();
+            message = string(result);
+            c2pa_release_string(result);
+        }
 
         virtual const char *what() const throw()
         {
-            return message;
+            return message.c_str();
         }
     };
 
     // Return the version of the C2pa library
-    String version()
+    string version()
     {
-        return String(c2pa_version());
+        auto result = c2pa_version();
+        string str = string(result);
+        c2pa_release_string(result);
+        return str;
     }
 
     // Read a file and return the manifest json as a C2pa::String
     // Note: Paths are UTF-8 encoded, use std.filename.u8string().c_str() if needed
-    // filename: the name of the file to read
-    // data_dir: the directory to store binary resources (can be NULL)
-    // Returns a C2pa::String containing the manifest json
+    // source_path: path to the file to read
+    // data_dir: the directory to store binary resources (optional)
+    // Returns a string containing the manifest json if a manifest was found
     // Throws a C2pa::Exception for errors encountered by the C2pa library
-    String read_file(const char *filename, const char *data_dir = NULL)
+    std::optional<string> read_file(const path& source_path, const std::optional<path> data_dir = std::nullopt)
     {
-        char *result = c2pa_read_file(filename, data_dir);
+        const char* dir = data_dir.has_value() ? data_dir.value().c_str() : NULL;
+        char *result = c2pa_read_file(source_path.c_str(), dir);
         if (result == NULL)
-        {
+        {   
+            auto exception = Exception();
+            if (strstr(exception.what(), "ManifestNotFound") != NULL)
+            {
+                return std::nullopt;
+            }
             throw Exception();
         }
-        return String(result);
+        string str = string(result);
+        c2pa_release_string(result);
+        return str;
     }
 
     // Read a file and return an ingredient json as a C2pa::String
-    // filename: the name of the file to read
+    // source_path: path to the file to read
     // data_dir: the directory to store binary resources
-    // Returns a C2pa::String containing the manifest json
+    // Returns a string containing the manifest json
     // Throws a C2pa::Exception for errors encountered by the C2pa library
-    String read_ingredient_file(const char *filename, const char *data_dir)
+    string read_ingredient_file(const path& source_path, const path& data_dir)
     {
-        char *result = c2pa_read_ingredient_file(filename, data_dir);
+        char *result = c2pa_read_ingredient_file(source_path.c_str(), data_dir.c_str());
         if (result == NULL)
         {
             throw Exception();
         }
-        return String(result);
+        string str = string(result);
+        c2pa_release_string(result);
+        return str;
     }
 
     // Add the manifest and sign a file
-    // filename: the name of the source file to sign
-    // dest_path: the path to write the signed file
+    // source_path: path to the asset to be signed
+    // dest_path: the path to write the signed file to
     // manifest: the manifest json to add to the file
     // signer_info: the signer info to use for signing
-    // data_dir: the directory to store binary resources (can be NULL)
-    // Returns a C2pa::String containing the manifest binary
+    // data_dir: the directory to store binary resources (optional)
     // Throws a C2pa::Exception for errors encountered by the C2pa library
-    String sign_file(const char *source_path,
-                     const char *dest_path,
+    void sign_file(const path& source_path,
+                     const path& dest_path,
                      const char *manifest,
-                     SignerInfo signer_info,
-                     const char *data_dir = NULL)
+                     SignerInfo *signer_info,
+                     const std::optional<path> data_dir = std::nullopt)
     {
-        char *result = c2pa_sign_file(source_path, dest_path, manifest, signer_info, data_dir);
+        const char* dir = data_dir.has_value() ? data_dir.value().c_str() : NULL;
+        char *result = c2pa_sign_file(source_path.c_str(), dest_path.c_str(), manifest, signer_info, dir);
         if (result == NULL)
         {
+
             throw Exception();
         }
-        return String(result);
+        c2pa_release_string(result);
+        return;
     }
-
 }

--- a/src/c_api.rs
+++ b/src/c_api.rs
@@ -180,7 +180,7 @@ pub unsafe extern "C" fn c2pa_sign_file(
     source_path: *const c_char,
     dest_path: *const c_char,
     manifest: *const c_char,
-    signer_info: C2paSignerInfo,
+    signer_info: &C2paSignerInfo,
     data_dir: *const c_char,
 ) -> *mut c_char {
     // convert C pointers into Rust
@@ -196,7 +196,7 @@ pub unsafe extern "C" fn c2pa_sign_file(
         ta_url: from_cstr_option!(signer_info.ta_url),
     };
     // Read manifest from JSON and then sign and write it
-    let result = sign_file(&source_path, &dest_path, &manifest, signer_info, data_dir);
+    let result = sign_file(&source_path, &dest_path, &manifest, &signer_info, data_dir);
 
     match result {
         Ok(_c2pa_data) => to_c_string("".to_string()),

--- a/src/json_api.rs
+++ b/src/json_api.rs
@@ -47,7 +47,7 @@ pub fn sign_file(
     source: &str,
     dest: &str,
     manifest_json: &str,
-    signer_info: SignerInfo,
+    signer_info: &SignerInfo,
     data_dir: Option<String>,
 ) -> Result<Vec<u8>> {
     let mut manifest = Manifest::from_json(manifest_json).map_err(Error::from_c2pa_error)?;

--- a/tests/test.c
+++ b/tests/test.c
@@ -39,13 +39,13 @@ int main(void)
     // create a sign_info struct
     C2paSignerInfo sign_info = {.alg = "es256", .sign_cert = certs, .private_key = private_key, .ta_url = "http://timestamp.digicert.com"};
 
-    result = c2pa_sign_file("tests/fixtures/C.jpg", "target/tmp/earth.jpg", manifest, sign_info, "tests/fixtures");
+    result = c2pa_sign_file("tests/fixtures/C.jpg", "target/tmp/earth.jpg", manifest, &sign_info, "tests/fixtures");
     assert_not_null("c2pa_sign_file_ok", result);
 
-    result = c2pa_sign_file("tests/fixtures/foo.jpg", "target/tmp/earth.jpg", manifest, sign_info, "tests/fixtures");
+    result = c2pa_sign_file("tests/fixtures/foo.jpg", "target/tmp/earth.jpg", manifest, &sign_info, "tests/fixtures");
     assert_null("c2pa_sign_file_not_found", result, "FileNotFound");
 
-    result = c2pa_sign_file("tests/fixtures/es256_certs.pem", "target/tmp/earth.jpg", manifest, sign_info, "tests/fixtures");
+    result = c2pa_sign_file("tests/fixtures/es256_certs.pem", "target/tmp/earth.jpg", manifest, &sign_info, "tests/fixtures");
     assert_null("c2pa_sign_file_not_supported", result, "NotSupported");
 
     free(certs);

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -12,14 +12,15 @@
 
 #include <iostream>
 #include <stdlib.h>
+#include <string.h>
 #include "../include/c2pa.hpp"
 
 // assert that c2pa_str contains substr or exit
-void assert_contains(const char *what, C2pa::String *c2pa_str, const char *substr)
+void assert_contains(const char *what, std::string str, const char *substr)
 {
-    if (strstr(c2pa_str->c_str(), substr) == NULL)
+    if (strstr(str.c_str(), substr) == NULL)
     {
-        fprintf(stderr, "FAILED %s: %s not found in %s\n", what, c2pa_str->c_str(), substr);
+        fprintf(stderr, "FAILED %s: %s not found in %s\n", what, str.c_str(), substr);
         exit(1);
     }
     printf("PASSED: %s\n", what);
@@ -30,17 +31,52 @@ using namespace std;
 int main()
 {
     auto version = C2pa::version();
-    assert_contains("C2pa::version", &version, "c2pa-c/0.");
+    assert_contains("C2pa::version", version, "c2pa-c/0.");
 
     try
     {
         // read a file with a valid manifest
         auto manifest_json = C2pa::read_file("tests/fixtures/C.jpg", "target/tmp");
-        assert_contains("C2pa::read_file", &manifest_json, "C.jpg");
+        if (manifest_json.has_value())
+        {
+            assert_contains("C2pa::read_file", manifest_json.value(), "C.jpg");
+        }
+        else
+        {
+            cout << "Failed: C2pa::read_file_: manifest_json is empty" << endl;
+            return (1);
+        }
     }
     catch (C2pa::Exception e)
     {
         cout << "Failed: C2pa::read_file_: " << e.what() << endl;
         return (1);
+    };
+
+    try
+    {
+        // read a file with with no manifest and no data_dir
+        auto manifest_json2 = C2pa::read_file("tests/fixtures/A.jpg");
+        if (manifest_json2.has_value())
+        {
+            cout << "Failed: C2pa::read_file_no_manifest: manifest_json2 is not empty" << endl;
+            return (1);
+        }
+    }
+    catch (C2pa::Exception e)
+    {
+        cout << "Failed: C2pa::read_file_no_manifest: " << e.what() << endl;
+    };
+
+     try
+    {
+        // read a file with with no manifest and no data_dir
+        auto manifest_json2 = C2pa::read_file("tests/fixtures/Z.jpg");
+        cout << "Failed: C2pa::read_file_not_found";
+        return (1);
+    }
+    catch (C2pa::Exception e)
+    {
+        assert_contains("C2pa::read_file_not_found", e.what(), "No such file or directory");
     };
 }


### PR DESCRIPTION
requires c++17 or greater
uses std::path for path parameters
use optional for optional params
returns an optional string from read_file (no string if no manifest) functions return standard C++ strings
sign_file now returns void
SignerInfo passed by reference