### PR TITLE
Export some of this as a Rust library so the c2pa-python can use it.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "c2pa-c"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 authors = ["Gavin Peacock <gpeacock@adobe.com"]
 
@@ -8,7 +8,7 @@ authors = ["Gavin Peacock <gpeacock@adobe.com"]
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-c2pa = {version="0.28.0", features = ["file_io", "add_thumbnails", "fetch_remote_manifests"]}
+c2pa = {version="0.28.4", features = ["file_io", "add_thumbnails", "fetch_remote_manifests"]}
 serde = { version = "1.0", features = ["derive"] }
 serde_derive = "1.0"
 serde_json = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 authors = ["Gavin Peacock <gpeacock@adobe.com"]
 
 [lib]
-crate-type = ["cdylib"]
+crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 c2pa = {version="0.28.0", features = ["file_io", "add_thumbnails", "fetch_remote_manifests"]}

--- a/src/json_api.rs
+++ b/src/json_api.rs
@@ -14,6 +14,11 @@ use c2pa::{Ingredient, Manifest, ManifestStore};
 
 use crate::{Error, Result, SignerInfo};
 
+/// Returns the version of the c2pa SDK used in this library
+pub fn sdk_version() -> String {
+    String::from(c2pa::VERSION)
+}
+
 /// Returns ManifestStore JSON string from a file path.
 ///
 /// If data_dir is provided, any thumbnail or c2pa data will be written to that folder.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,5 +17,5 @@ mod json_api;
 mod signer_info;
 
 pub use error::{Error, Result};
-pub use json_api::*;
+pub use json_api::{read_file, read_ingredient_file, sdk_version, sign_file};
 pub use signer_info::SignerInfo;


### PR DESCRIPTION
Exports the pure rust portions of this code so that it can be shared, rather than duplicated in the c2pa-python branch.
Eventually we may want to move all the common Rust code into a v2 version of c2pa-rs.