### PR TITLE
adds google-test and a few simple tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,5 +41,5 @@ file(GLOB unit_test_files CONFIGURE_DEPENDS "tests/*.test.cpp")
 add_executable(unit_tests ${unit_test_files})
 target_include_directories(unit_tests PUBLIC "${CMAKE_SOURCE_DIR}/include/")
 target_link_libraries(unit_tests nlohmann_json::nlohmann_json)
-target_link_libraries(unit_tests "${CMAKE_SOURCE_DIR}/target/debug/libc2pa_c.dylib")
+target_link_libraries(unit_tests "${CMAKE_SOURCE_DIR}/target/release/libc2pa_c.dylib")
 target_link_libraries(unit_tests gtest_main) # Links in gtest_main so we can run tests.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,45 @@
+# Copyright 2024 Adobe. All rights reserved.
+# This file is licensed to you under the Apache License,
+# Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+# or the MIT license (http://opensource.org/licenses/MIT),
+# at your option.
+#
+# Unless required by applicable law or agreed to in writing,
+# this software is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR REPRESENTATIONS OF ANY KIND, either express or
+# implied. See the LICENSE-MIT and LICENSE-APACHE files for the
+# specific language governing permissions and limitations under
+# each license.
+
+cmake_minimum_required(VERSION 3.27)
+
+project(c2pa-c)
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_CXX_STANDARD 20)
+
+# CMake Dependencies
+include(FetchContent)
+
+# Download GoogleTest testing framework.
+FetchContent_Declare(
+        googletest
+        # Specify the commit you depend on and update it regularly.
+        URL https://github.com/google/googletest/archive/5376968f6948923e2411081fd9372e71a59d8e77.zip
+)
+
+# For Windows: Prevent overriding the parent project's compiler/linker settings
+set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+FetchContent_MakeAvailable(googletest)
+
+# Download json
+FetchContent_Declare(json URL https://github.com/nlohmann/json/releases/download/v3.11.3/json.tar.xz)
+FetchContent_MakeAvailable(json)
+
+# Create the unit test target.
+file(GLOB unit_test_files CONFIGURE_DEPENDS "tests/*.test.cpp")
+add_executable(unit_tests ${unit_test_files})
+target_include_directories(unit_tests PUBLIC "${CMAKE_SOURCE_DIR}/include/")
+target_link_libraries(unit_tests nlohmann_json::nlohmann_json)
+target_link_libraries(unit_tests "${CMAKE_SOURCE_DIR}/target/debug/libc2pa_c.dylib")
+target_link_libraries(unit_tests gtest_main) # Links in gtest_main so we can run tests.

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,13 @@ test-rust:
 	cargo test --
 	cbindgen --config cbindgen.toml --crate c2pa-c --output include/c2pa.h --lang c
 
-release: 
+unit-tests: test-rust
+	mkdir -p target/cmake
+	cmake -S./ -B./target/cmake -G "Ninja"
+	cmake --build ./target/cmake --target unit_tests
+	cd target/cmake; ./unit_tests
+
+release:
 	cargo build --release
 	cbindgen --config cbindgen.toml --crate c2pa-c --output include/c2pa.h --lang c
 

--- a/README.md
+++ b/README.md
@@ -142,6 +142,10 @@ Install [cbindgen](https://github.com/mozilla/cbindgen/blob/master/docs.md):
 cargo install --force cbindgen
 ```
 
+The c unit tests require Ninja. Installation instructions are here:
+
+https://github.com/ninja-build/ninja/wiki/Pre-built-Ninja-packages
+
 ### Building 
 
 Building the library requires [GNU make](https://www.gnu.org/software/make/), which is installed on most macOS systems.

--- a/include/c2pa.hpp
+++ b/include/c2pa.hpp
@@ -13,6 +13,18 @@
 #ifndef C2PA_H
 #define C2PA_H
 
+// Suppress unused function warning for GCC/Clang
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-function"
+#endif
+
+// Suppress unused function warning for MSVC
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable: 4505)
+#endif
+
 #include <fstream>
 #include <iostream>
 #include <optional>  // C++17
@@ -727,5 +739,14 @@ namespace c2pa
 
     };
 }
+
+// Restore warnings
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
+
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
 
 #endif // C2PA_H

--- a/include/c2pa.hpp
+++ b/include/c2pa.hpp
@@ -10,8 +10,11 @@
 // specific language governing permissions and limitations under
 // each license.
 
+#ifndef C2PA_H
+#define C2PA_H
+
+#include <fstream>
 #include <iostream>
-#include <string.h>
 #include <optional>  // C++17
 #include <filesystem> // C++17
 
@@ -45,7 +48,7 @@ namespace c2pa
     };
 
     // Return the version of the C2pa library
-    string version()
+    static string version()
     {
         auto result = c2pa_version();
         string str = string(result);
@@ -56,7 +59,7 @@ namespace c2pa
     /// Load c2pa settings from a string in a given format
     /// @param format the mime format of the string
     /// @param data the string to load
-    void load_settings(const string format, const string data)
+    static void load_settings(const string format, const string data)
     {
         c2pa_load_settings(format.c_str(), data.c_str());
     }   
@@ -67,7 +70,7 @@ namespace c2pa
     // data_dir: the directory to store binary resources (optional)
     // Returns a string containing the manifest json if a manifest was found
     // Throws a C2pa::Exception for errors encountered by the C2pa library
-    std::optional<string> read_file(const std::filesystem::path& source_path, const std::optional<path> data_dir = std::nullopt)
+    static std::optional<string> read_file(const std::filesystem::path& source_path, const std::optional<path> data_dir = std::nullopt)
     {
         const char* dir = data_dir.has_value() ? data_dir.value().c_str() : NULL;
         char *result = c2pa_read_file(source_path.c_str(), dir);
@@ -90,7 +93,7 @@ namespace c2pa
     // data_dir: the directory to store binary resources
     // Returns a string containing the manifest json
     // Throws a C2pa::Exception for errors encountered by the C2pa library
-    string read_ingredient_file(const path& source_path, const path& data_dir)
+    static string read_ingredient_file(const path& source_path, const path& data_dir)
     {
         char *result = c2pa_read_ingredient_file(source_path.c_str(), data_dir.c_str());
         if (result == NULL)
@@ -109,7 +112,7 @@ namespace c2pa
     // signer_info: the signer info to use for signing
     // data_dir: the directory to store binary resources (optional)
     // Throws a C2pa::Exception for errors encountered by the C2pa library
-    void sign_file(const path& source_path,
+    static void sign_file(const path& source_path,
                      const path& dest_path,
                      const char *manifest,
                      SignerInfo *signer_info,
@@ -504,7 +507,7 @@ namespace c2pa
 
 
     // this static callback interfaces with the C level library allowing C++ to use vectors
-    intptr_t signer_passthrough(const void *context, const unsigned char *data, uintptr_t len, unsigned char *signature, uintptr_t sig_max_len) {
+    static intptr_t signer_passthrough(const void *context, const unsigned char *data, uintptr_t len, unsigned char *signature, uintptr_t sig_max_len) {
         // the context is a pointer to the C++ callback function
         SignerFunc *callback = (SignerFunc *)context;
         std::vector<uint8_t> data_vec(data, data + len);
@@ -724,3 +727,5 @@ namespace c2pa
 
     };
 }
+
+#endif // C2PA_H

--- a/include/file_stream.h
+++ b/include/file_stream.h
@@ -11,6 +11,9 @@
 // specific language governing permissions and limitations under
 // each license.#include "c2pa.h"
 
+#ifndef C2PA_FSTREAM_H
+#define C2PA_FSTREAM_H
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -94,3 +97,5 @@ int close_file_stream(CStream* stream) {
     c2pa_release_stream(stream);
     return result;
 }
+
+#endif

--- a/tests/read_file.test.cpp
+++ b/tests/read_file.test.cpp
@@ -1,0 +1,32 @@
+// Copyright 2024 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License,
+// Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+// or the MIT license (http://opensource.org/licenses/MIT),
+// at your option.
+// Unless required by applicable law or agreed to in writing,
+// this software is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR REPRESENTATIONS OF ANY KIND, either express or
+// implied. See the LICENSE-MIT and LICENSE-APACHE files for the
+// specific language governing permissions and limitations under
+// each license.
+
+#include <c2pa.hpp>
+#include <gtest/gtest.h>
+#include <nlohmann/json.hpp>
+
+using nlohmann::json;
+
+TEST(ReadFile, ReadFileWithNoManifestReturnsEmptyOptional) {
+  auto result = c2pa::read_file("../../tests/fixtures/A.jpg");
+  ASSERT_TRUE(result->empty());
+};
+
+TEST(ReadFile, ReadFileWithManifestReturnsSomeValue) {
+  auto result = c2pa::read_file("../../tests/fixtures/C.jpg");
+  ASSERT_TRUE(result.has_value());
+
+  // parse result with json
+  auto json = json::parse(result.value());
+  EXPECT_TRUE(json.contains("manifests"));
+  EXPECT_TRUE(json.contains("active_manifest"));
+};

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -77,9 +77,6 @@ std::vector<unsigned char> my_signer(const std::vector<unsigned char>& data) {
 
 int main()
 {
-    auto version = c2pa::version();
-    assert_contains("c2pa::version", version, "c2pa-c/0.");
-
     // test v2 ManifestStoreReader apis
     try {
 
@@ -91,9 +88,7 @@ int main()
 
         auto reader = c2pa::Reader("image/jpeg", ifs);
 
-        // auto reader = c2pa::Reader("tests/fixtures/C.jpg");
-
-        auto json = reader.json(); 
+        auto json = reader.json();
         assert_contains("c2pa::Reader.json", json, "C.jpg");
 
         auto thumb_path = "target/tmp/test_thumbail.jpg";
@@ -168,52 +163,5 @@ int main()
     catch (c2pa::Exception e) {
         cout << "Failed: C2pa::Builder: " << e.what() << endl;
         return (1);
-    };
-
-    try
-    {
-        // read a file with a valid manifest
-        auto manifest_json = c2pa::read_file("tests/fixtures/C.jpg", "target/tmp");
-        if (manifest_json.has_value())
-        {
-            assert_contains("c2pa::read_file", manifest_json.value(), "C.jpg");
-        }
-        else
-        {
-            cout << "Failed: c2pa::read_file_: manifest_json is empty" << endl;
-            return (1);
-        }
-    }
-    catch (c2pa::Exception e)
-    {
-        cout << "Failed: c2pa::read_file_: " << e.what() << endl;
-        return (1);
-    };
-
-    try
-    {
-        // read a file with with no manifest and no data_dir
-        auto manifest_json2 = c2pa::read_file("tests/fixtures/A.jpg");
-        if (manifest_json2.has_value())
-        {
-            cout << "Failed: c2pa::read_file_no_manifest: manifest_json2 is not empty" << endl;
-            return (1);
-        }
-    }
-    catch (c2pa::Exception e)
-    {
-        cout << "Failed: c2pa::read_file_no_manifest: " << e.what() << endl;
-    };
-
-     try
-    {
-        // read a file with with no manifest and no data_dir
-        auto manifest_json2 = c2pa::read_file("tests/fixtures/Z.jpg");
-        cout << "Failed: c2pa::read_file_not_found";
-        return (1);
-    }
-    catch (c2pa::Exception e)
-    {
-        assert_contains("c2pa::read_file_not_found", e.what(), "No such file or directory");
     };
 }

--- a/tests/version.test.cpp
+++ b/tests/version.test.cpp
@@ -1,0 +1,19 @@
+// Copyright 2024 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License,
+// Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+// or the MIT license (http://opensource.org/licenses/MIT),
+// at your option.
+// Unless required by applicable law or agreed to in writing,
+// this software is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR REPRESENTATIONS OF ANY KIND, either express or
+// implied. See the LICENSE-MIT and LICENSE-APACHE files for the
+// specific language governing permissions and limitations under
+// each license.
+
+#include <c2pa.hpp>
+#include <gtest/gtest.h>
+
+TEST(Version, VersionReturnsInCorrectFormat) {
+  auto version = c2pa::version();
+  ASSERT_TRUE(version.find("c2pa-c/0.") != std::string::npos);
+}


### PR DESCRIPTION
This PR adds google-test as a test runner to c2pa-c's V2 work. I've made a couple of changes to the CPP code that were required for the tests (and probably our other clients as well). 

### Changes

1. Adds a CMakeLists.txt file which does the following: 
    * Fetches Google Test and a simple JSON library
    * Creates a test runner executable named `unit_tests`. 
    * Allows any file in the `tests` directory with the pattern of `*.test.cpp` to be run with the google-test test runner.
2. Makes the functions defined in the `.hpp` static to prevent the duplicate symbols linker error when including `c2pa.hpp` into multiple test files.
3. Adds `ifndef` declarations to prevent duplicate definitions
4. Adds a few tests to the google-test runner and removes them from the test.cpp file.