### PR TITLE
feat: Adds data_hashed_embeddable support.

### DIFF
--- a/include/c2pa.h
+++ b/include/c2pa.h
@@ -596,6 +596,9 @@ struct C2paSigner *c2pa_signer_create(const void *context,
  * # Errors
  * Returns -1 if there were errors, otherwise returns the size to reserve.
  * The error string can be retrieved by calling c2pa_error.
+ *
+ * # Safety
+ * The signer_ptr must be a valid pointer to a C2paSigner.
  */
 IMPORT extern int64_t c2pa_signer_reserve_size(struct C2paSigner *signer_ptr);
 

--- a/include/c2pa.h
+++ b/include/c2pa.h
@@ -482,7 +482,7 @@ IMPORT extern int c2pa_builder_to_archive(struct C2paBuilder *builder_ptr, struc
  *
  * # Safety
  * Reads from NULL-terminated C strings
- * If c2pa_data_ptr is not NULL, the returned value MUST be released by calling c2pa_release_string
+ * If manifest_bytes_ptr is not NULL, the returned value MUST be released by calling c2pa_manifest_bytes_free
  * and it is no longer valid after that call.
  */
 IMPORT extern
@@ -500,6 +500,59 @@ int c2pa_builder_sign(struct C2paBuilder *builder_ptr,
  * The bytes can only be freed once and are invalid after this call.
  */
 IMPORT extern void c2pa_manifest_bytes_free(const unsigned char *manifest_bytes_ptr);
+
+/**
+ * Creates a hashed placeholder from a Builder.
+ * The placeholder is used to reserve size in an asset for later signing.
+ *
+ * # Parameters
+ * * builder_ptr: pointer to a Builder.
+ * * reserved_size: the size required for a signature from the intended signer.
+ * * format: pointer to a C string with the mime type or extension.
+ * * manifest_bytes_ptr: pointer to a pointer to a c_uchar to return manifest_bytes.
+ *
+ * # Errors
+ * Returns -1 if there were errors, otherwise returns the size of the manifest_bytes.
+ * The error string can be retrieved by calling c2pa_error.
+ *
+ * # Safety
+ * Reads from NULL-terminated C strings.
+ * If manifest_bytes_ptr is not NULL, the returned value MUST be released by calling c2pa_manifest_bytes_free
+ * and it is no longer valid after that call.
+ */
+IMPORT extern
+int c2pa_builder_data_hashed_placeholder(struct C2paBuilder *builder_ptr,
+                                         uintptr_t reserved_size,
+                                         const char *format,
+                                         const unsigned char **manifest_bytes_ptr);
+
+/**
+ * Sign a Builder using the specified signer and data hash.
+ * The data hash is a JSON string containing DataHash information for the asset.
+ * This is a low-level method for advanced use cases where the caller handles embedding the manifest.
+ *
+ * # Parameters
+ * * builder_ptr: pointer to a Builder.
+ * * signer: pointer to a C2paSigner.
+ * * data_hash: pointer to a C string with the JSON data hash.
+ * * format: pointer to a C string with the mime type or extension.
+ * * manifest_bytes_ptr: pointer to a pointer to a c_uchar to return manifest_bytes (optional, can be NULL).
+ *
+ * # Errors
+ * Returns -1 if there were errors, otherwise returns the size of the manifest_bytes.
+ * The error string can be retrieved by calling c2pa_error.
+ *
+ * # Safety
+ * Reads from NULL-terminated C strings.
+ * If manifest_bytes_ptr is not NULL, the returned value MUST be released by calling c2pa_manifest_bytes_free
+ * and it is no longer valid after that call.
+ */
+IMPORT extern
+int c2pa_builder_sign_data_hashed_embeddable(struct C2paBuilder *builder_ptr,
+                                             struct C2paSigner *signer,
+                                             const char *data_hash,
+                                             const char *format,
+                                             const unsigned char **manifest_bytes_ptr);
 
 /**
  * Creates a C2paSigner from a callback and configuration.
@@ -533,6 +586,18 @@ struct C2paSigner *c2pa_signer_create(const void *context,
                                       enum C2paSigningAlg alg,
                                       const char *certs,
                                       const char *tsa_url);
+
+/**
+ * Returns the size to reserve for the signature for this signer.
+ *
+ * # Parameters
+ * * signer_ptr: pointer to a C2paSigner.
+ *
+ * # Errors
+ * Returns -1 if there were errors, otherwise returns the size to reserve.
+ * The error string can be retrieved by calling c2pa_error.
+ */
+IMPORT extern int64_t c2pa_signer_reserve_size(struct C2paSigner *signer_ptr);
 
 /**
  * Frees a C2paSigner allocated by Rust.

--- a/include/c2pa.hpp
+++ b/include/c2pa.hpp
@@ -176,8 +176,12 @@ namespace c2pa
         Signer(SignerFunc *callback, C2paSigningAlg alg, const string &sign_cert, const string &tsa_uri);
 
         Signer(C2paSigner *signer) : signer(signer) {}
-        
+
         ~Signer();
+
+        /// @brief  Get the size to reserve for a signature for this signer.
+        /// @return Reserved size for the signature.
+        uintptr_t reserve_size();
 
         /// @brief  Get the C2paSigner
         C2paSigner *c2pa_signer();
@@ -267,6 +271,21 @@ namespace c2pa
         /// @param dest_path The path to write the archive file to.
         /// @throws C2pa::Exception for errors encountered by the C2PA library.
         void to_archive(const path &dest_path);
+
+        /// @brief Create a hashed placeholder from the builder.
+        /// @param reserved_size  The size required for a signature from the intended signer.
+        /// @param format  The format of the mime type or extension.
+        /// @return A vector containing the hashed placeholder.
+        /// @throws C2pa::Exception for errors encountered by the C2PA library.
+        std::unique_ptr<std::vector<unsigned char>> data_hashed_placeholder(uintptr_t reserved_size, const string &format);
+
+        /// @brief Sign a Builder using the specified signer and data hash.
+        /// @param signer  The signer to use for signing.
+        /// @param data_hash  The data hash to sign.
+        /// @param format  The format of the data hash.
+        /// @return A vector containing the signed data.
+        /// @throws C2pa::Exception for errors encountered by the C2PA library.
+        std::unique_ptr<std::vector<unsigned char>> sign_data_hashed_embeddable(Signer &signer, const string &data_hash, const string &format);
 
     private:
         // Private constructor for Builder from an archive (todo: find a better way to handle this)

--- a/src/c_api.rs
+++ b/src/c_api.rs
@@ -929,6 +929,9 @@ pub unsafe extern "C" fn c2pa_signer_create(
 /// # Errors
 /// Returns -1 if there were errors, otherwise returns the size to reserve.
 /// The error string can be retrieved by calling c2pa_error.
+///
+/// # Safety
+/// The signer_ptr must be a valid pointer to a C2paSigner.
 #[no_mangle]
 pub unsafe extern "C" fn c2pa_signer_reserve_size(signer_ptr: *mut C2paSigner) -> i64 {
     if signer_ptr.is_null() {
@@ -938,7 +941,7 @@ pub unsafe extern "C" fn c2pa_signer_reserve_size(signer_ptr: *mut C2paSigner) -
     let c2pa_signer: Box<C2paSigner> = Box::from_raw(signer_ptr);
     let size = c2pa_signer.signer.reserve_size() as i64;
     let _ = Box::into_raw(c2pa_signer);
-    return size;
+    size
 }
 
 /// Frees a C2paSigner allocated by Rust.

--- a/src/c_api.rs
+++ b/src/c_api.rs
@@ -18,8 +18,8 @@ use std::{
 
 // C has no namespace so we prefix things with C2PA to make them unique
 use c2pa::{
-    settings::load_settings_from_str, Builder as C2paBuilder, CallbackSigner, Reader as C2paReader,
-    SigningAlg,
+    assertions::DataHash, settings::load_settings_from_str, Builder as C2paBuilder, CallbackSigner,
+    Reader as C2paReader, SigningAlg,
 };
 
 use crate::{
@@ -69,6 +69,28 @@ impl From<C2paSigningAlg> for SigningAlg {
 #[repr(C)]
 pub struct C2paSigner {
     pub signer: Box<dyn c2pa::Signer>,
+}
+
+// Internal routine to test for null and return null error
+#[macro_export]
+macro_rules! null_check {
+    ($ptr : expr) => {
+        if $ptr.is_null() {
+            Error::set_last(Error::NullParameter(stringify!($ptr).to_string()));
+            return std::ptr::null_mut();
+        }
+    };
+}
+
+// Internal test for null and return -1 error
+#[macro_export]
+macro_rules! null_check_int {
+    ($ptr : expr) => {
+        if $ptr.is_null() {
+            Error::set_last(Error::NullParameter(stringify!($ptr).to_string()));
+            return -1;
+        }
+    };
 }
 
 // Internal routine to convert a *const c_char to a rust String or return a NULL error.
@@ -679,7 +701,7 @@ pub unsafe extern "C" fn c2pa_builder_to_archive(
 ///
 /// # Safety
 /// Reads from NULL-terminated C strings
-/// If c2pa_data_ptr is not NULL, the returned value MUST be released by calling c2pa_release_string
+/// If manifest_bytes_ptr is not NULL, the returned value MUST be released by calling c2pa_manifest_bytes_free
 /// and it is no longer valid after that call.
 #[no_mangle]
 pub unsafe extern "C" fn c2pa_builder_sign(
@@ -727,6 +749,109 @@ pub unsafe extern "C" fn c2pa_builder_sign(
 pub unsafe extern "C" fn c2pa_manifest_bytes_free(manifest_bytes_ptr: *const c_uchar) {
     if !manifest_bytes_ptr.is_null() {
         drop(Box::from_raw(manifest_bytes_ptr as *mut c_uchar));
+    }
+}
+
+/// Creates a hashed placeholder from a Builder.
+/// The placeholder is used to reserve size in an asset for later signing.
+///
+/// # Parameters
+/// * builder_ptr: pointer to a Builder.
+/// * reserved_size: the size required for a signature from the intended signer.
+/// * format: pointer to a C string with the mime type or extension.
+/// * manifest_bytes_ptr: pointer to a pointer to a c_uchar to return manifest_bytes.
+///
+/// # Errors
+/// Returns -1 if there were errors, otherwise returns the size of the manifest_bytes.
+/// The error string can be retrieved by calling c2pa_error.
+///
+/// # Safety
+/// Reads from NULL-terminated C strings.
+/// If manifest_bytes_ptr is not NULL, the returned value MUST be released by calling c2pa_manifest_bytes_free
+/// and it is no longer valid after that call.
+#[no_mangle]
+pub unsafe extern "C" fn c2pa_builder_data_hashed_placeholder(
+    builder_ptr: *mut C2paBuilder,
+    reserved_size: usize,
+    format: *const c_char,
+    manifest_bytes_ptr: *mut *const c_uchar,
+) -> c_int {
+    null_check_int!(builder_ptr);
+    null_check_int!(manifest_bytes_ptr);
+    let mut builder: Box<C2paBuilder> = Box::from_raw(builder_ptr);
+    let format = from_cstr_null_check_int!(format);
+    let result = builder.data_hashed_placeholder(reserved_size, &format);
+    let _ = Box::into_raw(builder);
+    match result {
+        Ok(manifest_bytes) => {
+            let len = manifest_bytes.len() as c_int;
+            *manifest_bytes_ptr =
+                Box::into_raw(manifest_bytes.into_boxed_slice()) as *const c_uchar;
+            len
+        }
+        Err(err) => {
+            Error::from_c2pa_error(err).set_last();
+            -1
+        }
+    }
+}
+
+/// Sign a Builder using the specified signer and data hash.
+/// The data hash is a JSON string containing DataHash information for the asset.
+/// This is a low-level method for advanced use cases where the caller handles embedding the manifest.
+///
+/// # Parameters
+/// * builder_ptr: pointer to a Builder.
+/// * signer: pointer to a C2paSigner.
+/// * data_hash: pointer to a C string with the JSON data hash.
+/// * format: pointer to a C string with the mime type or extension.
+/// * manifest_bytes_ptr: pointer to a pointer to a c_uchar to return manifest_bytes (optional, can be NULL).
+///
+/// # Errors
+/// Returns -1 if there were errors, otherwise returns the size of the manifest_bytes.
+/// The error string can be retrieved by calling c2pa_error.
+///
+/// # Safety
+/// Reads from NULL-terminated C strings.
+/// If manifest_bytes_ptr is not NULL, the returned value MUST be released by calling c2pa_manifest_bytes_free
+/// and it is no longer valid after that call.
+#[no_mangle]
+pub unsafe extern "C" fn c2pa_builder_sign_data_hashed_embeddable(
+    builder_ptr: *mut C2paBuilder,
+    signer: *mut C2paSigner,
+    data_hash: *const c_char,
+    format: *const c_char,
+    manifest_bytes_ptr: *mut *const c_uchar,
+) -> c_int {
+    null_check_int!(builder_ptr);
+    null_check_int!(manifest_bytes_ptr);
+
+    let mut builder: Box<C2paBuilder> = Box::from_raw(builder_ptr);
+    let c2pa_signer = Box::from_raw(signer);
+    let data_hash_json = from_cstr_null_check_int!(data_hash);
+    let data_hash: DataHash = match serde_json::from_str(&data_hash_json) {
+        Ok(data_hash) => data_hash,
+        Err(err) => {
+            Error::from_c2pa_error(c2pa::Error::JsonError(err)).set_last();
+            return -1;
+        }
+    };
+    let format = from_cstr_null_check_int!(format);
+    let result =
+        builder.sign_data_hashed_embeddable(c2pa_signer.signer.as_ref(), &data_hash, &format);
+    let _ = Box::into_raw(c2pa_signer);
+    let _ = Box::into_raw(builder);
+    match result {
+        Ok(manifest_bytes) => {
+            let len = manifest_bytes.len() as c_int;
+            *manifest_bytes_ptr =
+                Box::into_raw(manifest_bytes.into_boxed_slice()) as *const c_uchar;
+            len
+        }
+        Err(err) => {
+            Error::from_c2pa_error(err).set_last();
+            -1
+        }
     }
 }
 
@@ -794,6 +919,26 @@ pub unsafe extern "C" fn c2pa_signer_create(
     Box::into_raw(Box::new(C2paSigner {
         signer: Box::new(signer),
     }))
+}
+
+/// Returns the size to reserve for the signature for this signer.
+///
+/// # Parameters
+/// * signer_ptr: pointer to a C2paSigner.
+///
+/// # Errors
+/// Returns -1 if there were errors, otherwise returns the size to reserve.
+/// The error string can be retrieved by calling c2pa_error.
+#[no_mangle]
+pub unsafe extern "C" fn c2pa_signer_reserve_size(signer_ptr: *mut C2paSigner) -> i64 {
+    if signer_ptr.is_null() {
+        Error::set_last(Error::NullParameter(stringify!($ptr).to_string()));
+        return -1;
+    }
+    let c2pa_signer: Box<C2paSigner> = Box::from_raw(signer_ptr);
+    let size = c2pa_signer.signer.reserve_size() as i64;
+    let _ = Box::into_raw(c2pa_signer);
+    return size;
 }
 
 /// Frees a C2paSigner allocated by Rust.

--- a/tests/fixtures/training.json
+++ b/tests/fixtures/training.json
@@ -7,7 +7,7 @@
   ],
   "assertions": [
     {
-      "label": "c2pa.training-mining",
+      "label": "cawg.training-mining",
       "data": {
         "entries": {
           "cawg.ai_generative_training": {

--- a/tests/fixtures/training.json
+++ b/tests/fixtures/training.json
@@ -1,9 +1,8 @@
 {
-  "claim_generator": "c2pa-c_test/0.1",
   "claim_generator_info": [
     {
       "name": "c2pa-c test",
-      "version": "0.1"
+      "version": "0.2"
     }
   ],
   "assertions": [
@@ -11,16 +10,16 @@
       "label": "c2pa.training-mining",
       "data": {
         "entries": {
-          "c2pa.ai_generative_training": {
+          "cawg.ai_generative_training": {
             "use": "notAllowed"
           },
-          "c2pa.ai_inference": {
+          "cawg.ai_inference": {
             "use": "notAllowed"
           },
-          "c2pa.ai_training": {
+          "cawg.ai_training": {
             "use": "notAllowed"
           },
-          "c2pa.data_mining": {
+          "cawg.data_mining": {
             "use": "notAllowed"
           }
         }


### PR DESCRIPTION
Builder.data_hashed_placeholder
Builder.sign_data_hashed_embeddable
Adds Signer.reserve_size method.
Update training.json to use cawg values.