### PR TITLE
doc: Reorg, add conventional commit info, misc edits

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Before you start, we ask that you understand the following guidelines.
 
 ## Code of conduct
 
-This project adheres to the Adobe [code of conduct](../CODE_OF_CONDUCT.md). By participating,
+This project adheres to the Adobe [code of conduct](CODE_OF_CONDUCT.md). By participating,
 you are expected to uphold this code. Please report unacceptable behavior to
 [Grp-opensourceoffice@adobe.com](mailto:Grp-opensourceoffice@adobe.com).
 
@@ -18,26 +18,24 @@ consensus around project direction and issue solutions within issue threads
 
 ### Current areas of work
 
-The Adobe CAI team has been using this crate as the foundation of Adobe's Content Authenticity Initiative-related products and services since late 2020. As we shift toward making this crate available for open usage, we're aware that there is quite a bit of work to do to create what we'd feel comfortable calling a 1.0 release. We've decided to err on the side of releasing earlier so that people can experiment with it and give us feedback.
+Some broad categories of work (and thus things you might expect to change) are:
 
-We expect to do work on a number of areas in the next few months while we remain in prerelease (0.x) versions. Some broad categories of work (and thus things you might expect to change) are:
-
-* We'll be reviewing and refining our APIs for ease of use and comprehension. We'd appreciate feedback on areas that you find confusing or unnecessarily difficult.
-* We'll also be reviewing our APIs for compliance with Rust community best practices. There are some areas (for example, use of public fields and how we take ownership vs references) where we know some work is required.
-* Our documentation is incomplete. We'll be working on refining the documentation.
-* Our testing infrastructure is incomplete. We'll be working on improving test coverage, memory efficiency, and performance benchmarks.
+* API ease of use and comprehension. We'd appreciate feedback on areas that you find confusing or unnecessarily difficult.
+* API compliance with best practices. 
+* Documentation: We'll be working on refining the documentation.
+* Testing infrastructure: We'll be working on improving test coverage, memory efficiency, and performance benchmarks.
 
 ### Desired feedback
 
 We welcome feedback on:
 
-* API design
+* API design.
 * Prioritization of upcoming development, especially:
-  * File format support
-  * Assertion support
-* Optimizations and performance concerns
-* Bugs or non-compliance with the C2PA spec
-* Additional platform support
+  * File format support.
+  * Assertion support.
+* Optimizations and performance concerns.
+* Bugs or non-compliance with the C2PA spec.
+* Additional platform support.
 
 ## Contributor license agreement
 
@@ -61,11 +59,35 @@ This will give us an opportunity to discuss API design and avoid duplicate effor
 
 ### Pull request titles
 
-The build process automatically adds a pull request (PR) to the [CHANGELOG](CHANGELOG.md) unless the title of the PR begins with `(IGNORE)`. Start PR titles with `(IGNORE)` for minor documentation updates and other trivial fixes that you want to specifically exclude from the CHANGELOG.
+Titles of pull requests that target a long-lived branch such as _main_ or a release-specific branch should follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#specification). This means that the first word of the pull request title should be one of the following:
 
-Additionally, the build process takes specific actions if the title of a PR begins with certain special strings:
-- `(MINOR)`: Increments the minor version, per [semantic versioning](https://semver.org/) convention. **IMPORTANT:** This flag should be used for any API change that breaks compatibility with previous releases while this crate is in prerelease (version 0.x) status.
-- `(MAJOR)`: Increments the major version number, per [semantic versioning](https://semver.org/) convention.
+  * `build`
+  * `chore`
+  * `ci`
+  * `docs`
+  * `feat`
+  * `fix`
+  * `perf`
+  * `refactor`
+  * `revert`
+  * `style`
+  * `test`
+
+Optionally, but preferred, a scope can be added in parentheses after the type. The scope should be the name of the module or component that the commit affects. For example, `feat(api): Introduce a new API to validate 1.0 claims`.
+
+If more detail is warranted, add a blank line and then continue with sentences (these sentences should be punctuated as such) and paragraphs as needed to provide that detail. There is no need to word-wrap this message.
+
+For example:
+
+```text
+feat(api): Introduce a new API to validate 1.0 claims
+
+Repurpose existing v2 API for 0.8 compatibility (read: no validation) mode.
+```
+
+The conventional commit message requirement does not apply to individual commits within a pull request, provided that those commits will be squashed when the PR is merged and the resulting squash commit does follow the conventional commit requirement. This may require the person merging the PR to verify the commit message syntax when performing the squash merge.
+
+TIP: For single-commit PRs, ensure the commit message conforms to the conventional commit requirement, since by default that will also be the title of the PR.
 
 ## From contributor to committer
 

--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ For example:
 ```
 
 ### Creating Signer
+
 A sample test signer is provided in the tests folder. It is important that the private key is is kept private. The test signer
 should only be used for testing and development. In production a the private key should be kept in KMS or another secure environment. The SDK requires the public cert chain to be passed in here.
 
@@ -125,9 +126,11 @@ Signer signer = Signer(test_signer, Es256, certs, "http://timestamp.digicert.com
 ```
 
 ### Signing and embedding a manifest
+
 ```cpp
   auto manifest_data = builder.sign(image_path, output_path, signer);
 ```
+
 The parameters are:
 - `<SOURCE_ASSET>`- A file path or an istream referencing the asset to sign.
 - `<OUTPUT_ASSET>`- A file path or an iostream referencing the asset to generate.
@@ -197,29 +200,7 @@ The example displays some text to standard out that summarizes whether AI traini
 
 ## Supported file formats
 
- | Extensions    | MIME type                                           |
- |---------------| --------------------------------------------------- |
- | `avi`         | `video/msvideo`, `video/avi`, `application-msvideo` |
- | `avif`        | `image/avif`                                        |
- | `c2pa`        | `application/x-c2pa-manifest-store`                 |
- | `dng`         | `image/x-adobe-dng`                                 |
- | `heic`        | `image/heic`                                        |
- | `heif`        | `image/heif`                                        |
- | `jpg`, `jpeg` | `image/jpeg`                                        |
- | `m4a`         | `audio/mp4`                                         |
- | `mp3`         | `"audio/mpeg"`                                      |
- | `mp4`         | `video/mp4`, `application/mp4` <sup>*</sup>         |
- | `mov`         | `video/quicktime`                                   |
- | `pdf`         | `application/pdf`  <sup>**</sup>                    |
- | `png`         | `image/png`                                         |
- | `svg`         | `image/svg+xml`                                     |
- | `tif`,`tiff`  | `image/tiff`                                        |
- | `wav`         | `audio/x-wav`                                       |
- | `webp`        | `image/webp`                                        |
-
-<sup>*</sup> Fragmented mp4 is not yet supported.
-
-<sup>**</sup> Read only
+The C library [supports the same media file formats](https://github.com/contentauth/c2pa-rs/blob/main/docs/supported-formats.md) as the Rust library. 
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -8,8 +8,9 @@
 
 <div style={{display: 'none'}}>
 
-For the best experience, read the docs on the [CAI Open Source SDK documentation website](https://opensource.contentauthenticity.org/docs/c2pa-node/).  Some additional documentation for this repository is also available on GitHub:
+For the best experience, read the docs on the [CAI Open Source SDK documentation website](https://opensource.contentauthenticity.org/docs/c2pa-c).  If you want to view the documentation in GitHub, see:
 - [Using the C++ library](docs/usage.md)
+- [Supported formats](https://github.com/contentauth/c2pa-rs/blob/crandmck/reorg-docs/docs/supported-formats.md)
 
 </div>
 

--- a/README.md
+++ b/README.md
@@ -1,145 +1,33 @@
-# c2pa-c
+# C2PA C++ library
 
-This library implements C++ APIs that:
-- Read and validate C2PA data from media files in [supported formats](#supported-file-formats).
-- Add signed manifests to media files in [supported formats](#supported-file-formats).
+[The c2pa-c repository](https://github.com/contentauth/c2pa-c) implements C++ APIs that:
+- Read and validate C2PA data from media files in supported formats.
+- Add signed manifests to media files in supported formats.
 
 **WARNING**: This is a prerelease version of this library.  There may be bugs and unimplemented features, and the API is subject to change.
+
+<div style={{display: 'none'}}>
+
+For the best experience, read the docs on the [CAI Open Source SDK documentation website](https://opensource.contentauthenticity.org/docs/c2pa-node/).  Some additional documentation for this repository is also available on GitHub:
+- [Using the C++ library](docs/usage.md)
+
+</div>
 
 ## Installation
 
 ### CMake setup
-We build with CMake and you can use FetchContent like this:
-```FetchContent_Declare(
+Build the project using CMake and FetchContent like this:
+
+```c
+FetchContent_Declare(
     c2pa_cpp
     GIT_REPOSITORY https://github.com/contentauth/c2pa-c.git
     GIT_TAG gpeacock/cmake_work`
 )
 FetchContent_MakeAvailable(c2pa_cpp)
 ```
-And then add:
-```"${c2pa_cpp_SOURCE_DIR}/include"```
-to your include path.
 
-
-## Usage
-
-To use this library, include the header file in your code as follows:
-
-```cpp
-#include "c2pa.hpp"
-```
-
-### Read and validate an istream 
-
-Use the `Reader` constructor to read C2PA data from a stream. This constructor examines the specified stream for C2PA data in the given format and its return value is a Reader that can be used to extract more information. Exceptions are thrown on errors.
-
-```cpp
-  auto reader = c2pa::Reader(<"FORMAT">, <"STREAM">);
-```
-The parameters are:
-
-- `<FORMAT>`- A MIME string format for the stream [supported file formats](#supported-file-formats).
-- `<STREAM>` - An open readable iostream.
-For example:
-
-```cpp
-std::ifstream ifs("tests/fixtures/C.jpg", std::ios::binary);
-
-// the Reader supports streams or file paths
-auto reader = c2pa::Reader("image/jpeg", ifs);
-
-// print out the Manifest Store information
-printf("Manifest Store = %s", reader.json())
-
-// write the thumbnail into a file
-std::ofstream ofs("test_thumbail.jpg", std::ios::binary);
-reader.get_resource("self#jumbf=c2pa.assertions/c2pa.thumbnail.claim.jpeg", ofs);
-ifs.close();
-```
-
-### Creating a manifest JSON definition
-
-The manifest JSON string defines the C2PA manifest to add to the file.
-
-A sample JSON manifest is provided in [tests/fixtures/training.json](https://github.com/contentauth/c2pa-c/blob/main/tests/fixtures/training.json).
-
-For example:
-```cpp
-const std::string manifest_json = R"{
-    "claim_generator": "c2pa_c_test/0.1",
-    "claim_generator_info": [
-      {
-        "name": "c2pa-c test",
-        "version": "0.1"
-      }
-    ],
-    "assertions": [
-    {
-      "label": "c2pa.training-mining",
-      "data": {
-        "entries": {
-          "c2pa.ai_generative_training": { "use": "notAllowed" },
-          "c2pa.ai_inference": { "use": "notAllowed" },
-          "c2pa.ai_training": { "use": "notAllowed" },
-          "c2pa.data_mining": { "use": "notAllowed" }
-        }
-      }
-    }
-  ]
- };
-```
-
-### Creating a Builder
-
-Use the `Builder` constructor to create a `Builder` instance.
-
-```cpp
-  auto builder = Builder("<MANIFEST_JSON>");
-```
-The parameter is:
-- `<MANIFEST_JSON>`- A string in JSON format as as described above, defining the manifest to be generated.
-
-For example:
-
-```cpp
-  auto builder = Builder(manifest_json);
-```
-
-### Creating Signer
-
-A sample test signer is provided in the tests folder. It is important that the private key is is kept private. The test signer
-should only be used for testing and development. In production a the private key should be kept in KMS or another secure environment. The SDK requires the public cert chain to be passed in here.
-
-```cpp
-  Signer signer = Signer("<SIGNING_FUNCTION>","<SIGNING_ALG>", "<PUBLIC_CERTS>", "<TIMESTAMP_URL>");
-```
-The parameters are:
-- `<SIGNING_FUNCTION>`- A signing function that returns a signature using `<SIGNING_ALG>` over the bytes passed in.
-- `<SIGNING_ALG>`- The `C2paSigningAlg` from `c2pa.h` associated with the signing function.
-- `<PUBLIC_CERTS>`- A buffer containing the public cert chain.
-- `<TIMESTAMP_URL>`- An optional parameter containing a URL to a public Time Stamp Authority service.
-
-For example:
-```cpp
-Signer signer = Signer(test_signer, Es256, certs, "http://timestamp.digicert.com");
-```
-
-### Signing and embedding a manifest
-
-```cpp
-  auto manifest_data = builder.sign(image_path, output_path, signer);
-```
-
-The parameters are:
-- `<SOURCE_ASSET>`- A file path or an istream referencing the asset to sign.
-- `<OUTPUT_ASSET>`- A file path or an iostream referencing the asset to generate.
-- `<SIGNER>` - A `Signer` instance.
-
-For example: 
-```cpp
-  auto manifest_data = builder.sign("source_asset.jpg", "output_asset.jpg", signer);
-```
+And then add `"${c2pa_cpp_SOURCE_DIR}/include"` to your include path.
 
 ## Development
 
@@ -155,9 +43,7 @@ Install [cbindgen](https://github.com/mozilla/cbindgen/blob/master/docs.md):
 cargo install --force cbindgen
 ```
 
-The unit tests require Ninja. Installation instructions are here:
-
-https://github.com/ninja-build/ninja/wiki/Pre-built-Ninja-packages
+You must install the [Ninja](https://github.com/ninja-build/ninja/wiki/Pre-built-Ninja-packages) build system to run the unit tests. 
 
 ### Building 
 
@@ -169,7 +55,7 @@ Enter this command to build the C library:
 make release
 ```
 
-The Makefile also has multiple targets:
+The Makefile has a number of other targets; for example:
 - `unit-tests` to run C++ unit tests
 - `examples` to build and run the C++ examples.
 - `all` to run everything.
@@ -181,26 +67,8 @@ Results are saved in the `target` directory.
 Build the [unit tests](https://github.com/contentauth/c2pa-c/tree/main/tests) by entering this `make` command:
 
 ```
-make test
+make unit-test
 ```
-
-### Example
-
-The simple C++ example in [`examples/training.cpp`](https://github.com/contentauth/c2pa-c/blob/main/examples/training.cpp) uses the [JSON for Modern C++](https://json.nlohmann.me/) library class.
-
-Build and run the example by entering this `make` command:
-
-```
-make example
-```
-
-This example adds the manifest [`tests/fixtures/training.json`](https://github.com/contentauth/c2pa-c/blob/main/tests/fixtures/training.json) to the image file [`tests/fixtures/A.jpg`](https://github.com/contentauth/c2pa-c/blob/main/tests/fixtures/A.jpg) using the sample private key and certificate in the [`tests/fixtures`](https://github.com/contentauth/c2pa-c/tree/main/tests/fixtures) directory.
-
-The example displays some text to standard out that summarizes whether AI training is allowed based on the specified manifest and then saves the resulting image file with attached manifest to `target/example/training.jpg`.
-
-## Supported file formats
-
-The C library [supports the same media file formats](https://github.com/contentauth/c2pa-rs/blob/main/docs/supported-formats.md) as the Rust library. 
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # C2PA C++ library
 
-The[c2pa-c repository](https://github.com/contentauth/c2pa-c) implements C++ APIs that:
+The [c2pa-c repository](https://github.com/contentauth/c2pa-c) implements C++ APIs that:
 - Read and validate C2PA data from media files in supported formats.
 - Add signed manifests to media files in supported formats.
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # C2PA C++ library
 
-[The c2pa-c repository](https://github.com/contentauth/c2pa-c) implements C++ APIs that:
+The[c2pa-c repository](https://github.com/contentauth/c2pa-c) implements C++ APIs that:
 - Read and validate C2PA data from media files in supported formats.
 - Add signed manifests to media files in supported formats.
+
+Although this library works for plain C applications, the documentation assumes you're using C++, since that's most common for modern applications.
 
 **WARNING**: This is a prerelease version of this library.  There may be bugs and unimplemented features, and the API is subject to change.
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,0 +1,132 @@
+# Using the C++ library
+
+To use this library, include the header file in your code as follows:
+
+```cpp
+#include "c2pa.hpp"
+```
+
+## Read and validate an istream 
+
+Use the `Reader` constructor to read C2PA data from a stream. This constructor examines the specified stream for C2PA data in the given format and its return value is a Reader that can be used to extract more information. Exceptions are thrown on errors.
+
+```cpp
+  auto reader = c2pa::Reader(<"FORMAT">, <"STREAM">);
+```
+The parameters are:
+
+- `<FORMAT>`- A MIME string format for the stream [supported file formats](docs/supported-file-formats).
+- `<STREAM>` - An open readable iostream.
+For example:
+
+```cpp
+std::ifstream ifs("tests/fixtures/C.jpg", std::ios::binary);
+
+// the Reader supports streams or file paths
+auto reader = c2pa::Reader("image/jpeg", ifs);
+
+// print out the Manifest Store information
+printf("Manifest Store = %s", reader.json())
+
+// write the thumbnail into a file
+std::ofstream ofs("test_thumbail.jpg", std::ios::binary);
+reader.get_resource("self#jumbf=c2pa.assertions/c2pa.thumbnail.claim.jpeg", ofs);
+ifs.close();
+```
+
+## Creating a manifest JSON definition
+
+The manifest JSON string defines the C2PA manifest to add to the file.
+
+A sample JSON manifest is provided in [tests/fixtures/training.json](https://github.com/contentauth/c2pa-c/blob/main/tests/fixtures/training.json).
+
+For example:
+```cpp
+const std::string manifest_json = R"{
+    "claim_generator": "c2pa_c_test/0.1",
+    "claim_generator_info": [
+      {
+        "name": "c2pa-c test",
+        "version": "0.1"
+      }
+    ],
+    "assertions": [
+    {
+      "label": "c2pa.training-mining",
+      "data": {
+        "entries": {
+          "c2pa.ai_generative_training": { "use": "notAllowed" },
+          "c2pa.ai_inference": { "use": "notAllowed" },
+          "c2pa.ai_training": { "use": "notAllowed" },
+          "c2pa.data_mining": { "use": "notAllowed" }
+        }
+      }
+    }
+  ]
+ };
+```
+
+## Creating a Builder
+
+Use the `Builder` constructor to create a `Builder` instance.
+
+```cpp
+  auto builder = Builder("<MANIFEST_JSON>");
+```
+The parameter is:
+- `<MANIFEST_JSON>`- A string in JSON format as as described above, defining the manifest to be generated.
+
+For example:
+
+```cpp
+  auto builder = Builder(manifest_json);
+```
+
+## Creating a Signer
+
+A sample test signer is provided in the tests folder. It is important that the private key is is kept private. The test signer
+should only be used for testing and development. In production a the private key should be kept in KMS or another secure environment. The SDK requires the public cert chain to be passed in here.
+
+```cpp
+  Signer signer = Signer("<SIGNING_FUNCTION>","<SIGNING_ALG>", "<PUBLIC_CERTS>", "<TIMESTAMP_URL>");
+```
+The parameters are:
+- `<SIGNING_FUNCTION>`- A signing function that returns a signature using `<SIGNING_ALG>` over the bytes passed in.
+- `<SIGNING_ALG>`- The `C2paSigningAlg` from `c2pa.h` associated with the signing function.
+- `<PUBLIC_CERTS>`- A buffer containing the public cert chain.
+- `<TIMESTAMP_URL>`- An optional parameter containing a URL to a public Time Stamp Authority service.
+
+For example:
+```cpp
+Signer signer = Signer(test_signer, Es256, certs, "http://timestamp.digicert.com");
+```
+
+## Signing and embedding a manifest
+
+```cpp
+  auto manifest_data = builder.sign(image_path, output_path, signer);
+```
+
+The parameters are:
+- `<SOURCE_ASSET>`- A file path or an istream referencing the asset to sign.
+- `<OUTPUT_ASSET>`- A file path or an iostream referencing the asset to generate.
+- `<SIGNER>` - A `Signer` instance.
+
+For example: 
+```cpp
+  auto manifest_data = builder.sign("source_asset.jpg", "output_asset.jpg", signer);
+```
+
+## More examples
+
+The simple C++ example in [`examples/training.cpp`](https://github.com/contentauth/c2pa-c/blob/main/examples/training.cpp) uses the [JSON for Modern C++](https://json.nlohmann.me/) library class.
+
+Build and run the example by entering this `make` command:
+
+```
+make examples
+```
+
+This example adds the manifest [`tests/fixtures/training.json`](https://github.com/contentauth/c2pa-c/blob/main/tests/fixtures/training.json) to the image file [`tests/fixtures/A.jpg`](https://github.com/contentauth/c2pa-c/blob/main/tests/fixtures/A.jpg) using the sample private key and certificate in the [`tests/fixtures`](https://github.com/contentauth/c2pa-c/tree/main/tests/fixtures) directory.
+
+The example displays some text to standard out that summarizes whether AI training is allowed based on the specified manifest and then saves the resulting image file with attached manifest to `target/example/training.jpg`.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -15,8 +15,9 @@ Use the `Reader` constructor to read C2PA data from a stream. This constructor e
 ```
 The parameters are:
 
-- `<FORMAT>`- A MIME string format for the stream [supported file formats](docs/supported-file-formats).
+- `<FORMAT>`- A MIME string format for the stream; must be one of the [supported file formats](supported-formats.md).
 - `<STREAM>` - An open readable iostream.
+
 For example:
 
 ```cpp


### PR DESCRIPTION
- Break out usage info into separate file, to align with organization in other repos.
- Add conventional commits guidance to CONTRIBUTING.md
- Fixed broken links, clarified contribution areas, etc.
