### PR TITLE
chore: returns a std::vector instead of a std::unique_ptr<std::vector>>

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,21 +8,15 @@ authors = ["Gavin Peacock <gpeacock@adobe.com"]
 crate-type = ["lib", "cdylib"]
 
 [dependencies]
-c2pa = { version = "0.38.0", features = [
+c2pa = { version = "0.40.0", features = [
     "unstable_api",
     "file_io",
     "add_thumbnails",
     "fetch_remote_manifests",
 ] }
-pem = "3.0.4"
 serde = { version = "1.0", features = ["derive"] }
-serde_derive = "1.0"
 serde_json = "1.0"
 thiserror = "1.0.64"
-
-[dev-dependencies]
-url = "2.2.2" 
-
 
 [profile.release]
 strip = true # Strip symbols from the output binary.

--- a/include/c2pa.hpp
+++ b/include/c2pa.hpp
@@ -242,7 +242,7 @@ namespace c2pa
         /// @param signer
         /// @return A vector containing the signed manifest bytes.
         /// @throws C2pa::Exception for errors encountered by the C2PA library.
-        std::unique_ptr<std::vector<unsigned char>> sign(const string &format, istream &source, ostream &dest, Signer &signer);
+        std::vector<unsigned char> sign(const string &format, istream &source, ostream &dest, Signer &signer);
 
         /// @brief Sign a file and write the signed data to an output file.
         /// @param source_path The path to the file to sign.
@@ -250,7 +250,7 @@ namespace c2pa
         /// @param signer A signer object to use when signing.
         /// @return A vector containing the signed manifest bytes.
         /// @throws C2pa::Exception for errors encountered by the C2PA library.
-        std::unique_ptr<std::vector<unsigned char>> sign(const path &source_path, const path &dest_path, Signer &signer);
+        std::vector<unsigned char> sign(const path &source_path, const path &dest_path, Signer &signer);
 
         /// @brief Create a Builder from an archive.
         /// @param archive  The input stream to read the archive from.
@@ -277,7 +277,7 @@ namespace c2pa
         /// @param format  The format of the mime type or extension.
         /// @return A vector containing the hashed placeholder.
         /// @throws C2pa::Exception for errors encountered by the C2PA library.
-        std::unique_ptr<std::vector<unsigned char>> data_hashed_placeholder(uintptr_t reserved_size, const string &format);
+        std::vector<unsigned char> data_hashed_placeholder(uintptr_t reserved_size, const string &format);
 
         /// @brief Sign a Builder using the specified signer and data hash.
         /// @param signer  The signer to use for signing.
@@ -285,7 +285,7 @@ namespace c2pa
         /// @param format  The format of the data hash.
         /// @return A vector containing the signed data.
         /// @throws C2pa::Exception for errors encountered by the C2PA library.
-        std::unique_ptr<std::vector<unsigned char>> sign_data_hashed_embeddable(Signer &signer, const string &data_hash, const string &format);
+        std::vector<unsigned char> sign_data_hashed_embeddable(Signer &signer, const string &data_hash, const string &format);
 
     private:
         // Private constructor for Builder from an archive (todo: find a better way to handle this)

--- a/tests/builder.test.cpp
+++ b/tests/builder.test.cpp
@@ -96,7 +96,7 @@ TEST(Builder, SignStream)
         // Create a memory buffer
         std::stringstream memory_buffer(std::ios::in | std::ios::out | std::ios::binary);
         std::iostream &dest = memory_buffer;
-        auto manifest_data = builder.sign("image/jpeg", source, dest, signer);
+        auto _ = builder.sign("image/jpeg", source, dest, signer);
         source.close();
 
         // Rewind dest to the start
@@ -104,7 +104,7 @@ TEST(Builder, SignStream)
         dest.seekp(0, std::ios::beg);
         auto reader = c2pa::Reader("image/jpeg", dest);
         auto json = reader.json();
-        ASSERT_TRUE(json.find("c2pa.training-mining") != std::string::npos);
+        ASSERT_TRUE(json.find("cawg.training-mining") != std::string::npos);
     }
     catch (c2pa::Exception const &e)
     {


### PR DESCRIPTION

The contents of the std::vector (the signature and the data hashed
placeholder) are put on the heap already because of std::vector's
implementation.

