### PR TITLE
feat: Update c2pa_rs api with early v2 claim testing support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,11 +8,11 @@ authors = ["Gavin Peacock <gpeacock@adobe.com"]
 crate-type = ["lib", "cdylib"]
 
 [dependencies]
-c2pa = { version = "0.43.0", features = [
-    "unstable_api",
+c2pa = { git="https://github.com/contentauth/c2pa-rs", branch = "main", features = [
     "file_io",
     "add_thumbnails",
     "fetch_remote_manifests",
+    "v1_api",
 ] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ authors = ["Gavin Peacock <gpeacock@adobe.com"]
 crate-type = ["lib", "cdylib"]
 
 [dependencies]
-c2pa = { git="https://github.com/contentauth/c2pa-rs", branch = "main", features = [
+c2pa = { version = "0.44.0", features = [
     "file_io",
     "add_thumbnails",
     "fetch_remote_manifests",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "c2pa-c"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 authors = ["Gavin Peacock <gpeacock@adobe.com"]
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -81,7 +81,7 @@ impl Error {
             | TooManyManifestStores => Self::Manifest(err_str),
             ClaimMissing { label } => Self::ManifestNotFound(err_str),
             AssertionDecoding(_) | ClaimDecoding => Self::Decoding(err_str),
-            AssertionEncoding | XmlWriteError | ClaimEncoding => Self::Encoding(err_str),
+            AssertionEncoding(_) | XmlWriteError | ClaimEncoding => Self::Encoding(err_str),
             InvalidCoseSignature { coset_error } => Self::Signature(err_str),
             CoseSignatureAlgorithmNotSupported
             | CoseMissingKey

--- a/tests/fixtures/training.json
+++ b/tests/fixtures/training.json
@@ -1,4 +1,5 @@
 {
+  "claim_version": 1,
   "claim_generator_info": [
     {
       "name": "c2pa-c test",


### PR DESCRIPTION
v2 claims may be created by adding a claim_version = 2 value to a manifest defintion. This is only for early testing since we are still completing work on this feature.