### PR TITLE
chore: Up c2pa Rust dependency version to latest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ authors = ["Gavin Peacock <gpeacock@adobe.com"]
 crate-type = ["lib", "cdylib"]
 
 [dependencies]
-c2pa = { version = "0.45.0", features = [
+c2pa = { version = "0.45.1", features = [
     "file_io",
     "add_thumbnails",
     "fetch_remote_manifests",


### PR DESCRIPTION
Up c2pa Rust dependency version to latest