### PR TITLE
fix: Updates Stream callbacks to use consistent uintptr_t values

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "c2pa-c"
-version = "0.4.1"
+version = "0.5.0"
 edition = "2021"
 authors = ["Gavin Peacock <gpeacock@adobe.com"]
 

--- a/include/c2pa.h
+++ b/include/c2pa.h
@@ -39,6 +39,18 @@
 
 
 /**
+ * An enum to define the seek mode for the seek callback
+ * Start - seek from the start of the stream
+ * Current - seek from the current position in the stream
+ * End - seek from the end of the stream
+ */
+typedef enum C2paSeekMode {
+  Start = 0,
+  Current = 1,
+  End = 2,
+} C2paSeekMode;
+
+/**
  * List of supported signing algorithms.
  */
 typedef enum C2paSigningAlg {
@@ -92,22 +104,29 @@ typedef struct StreamContext {
 
 /**
  * Defines a callback to read from a stream
+ * The return value is the number of bytes read, or a negative number for an error
  */
-typedef intptr_t (*ReadCallback)(const struct StreamContext *context, uint8_t *data, uintptr_t len);
+typedef intptr_t (*ReadCallback)(struct StreamContext *context, uint8_t *data, intptr_t len);
 
 /**
  * Defines a callback to seek to an offset in a stream
+ * The return value is the new position in the stream, or a negative number for an error
  */
-typedef int (*SeekCallback)(const struct StreamContext *context, long offset, int mode);
+typedef intptr_t (*SeekCallback)(struct StreamContext *context,
+                                 intptr_t offset,
+                                 enum C2paSeekMode mode);
 
 /**
  * Defines a callback to write to a stream
+ * The return value is the number of bytes written, or a negative number for an error
  */
-typedef intptr_t (*WriteCallback)(const struct StreamContext *context,
-                                  const uint8_t *data,
-                                  uintptr_t len);
+typedef intptr_t (*WriteCallback)(struct StreamContext *context, const uint8_t *data, intptr_t len);
 
-typedef intptr_t (*FlushCallback)(const struct StreamContext *context);
+/**
+ * Defines a callback to flush a stream
+ * The return value is 0 for success, or a negative number for an error
+ */
+typedef intptr_t (*FlushCallback)(struct StreamContext *context);
 
 /**
  * A CStream is a Rust Read/Write/Seek stream that can be created in C

--- a/include/c2pa.hpp
+++ b/include/c2pa.hpp
@@ -125,10 +125,10 @@ namespace c2pa
         ~CppIStream();
 
     private:
-        static size_t reader(StreamContext *context, void *buffer, size_t size);
-        static int writer(StreamContext *context, const void *buffer, int size);
-        static long seeker(StreamContext *context, long int offset, int whence);
-        static int flusher(StreamContext *context);
+        static intptr_t reader(StreamContext *context, uint8_t *buffer, intptr_t size);
+        static intptr_t writer(StreamContext *context, const uint8_t *buffer, intptr_t size);
+        static intptr_t seeker(StreamContext *context, intptr_t offset, C2paSeekMode whence);
+        static intptr_t flusher(StreamContext *context);
 
         friend class Reader;
     };
@@ -145,10 +145,10 @@ namespace c2pa
         ~CppOStream();
 
     private:
-        static size_t reader(StreamContext *context, void *buffer, size_t size);
-        static int writer(StreamContext *context, const void *buffer, int size);
-        static long seeker(StreamContext *context, long int offset, int whence);
-        static int flusher(StreamContext *context);
+        static intptr_t reader(StreamContext *context, uint8_t *buffer, intptr_t size);
+        static intptr_t writer(StreamContext *context, const uint8_t *buffer, intptr_t size);
+        static intptr_t seeker(StreamContext *context, intptr_t offset, C2paSeekMode whence);
+        static intptr_t flusher(StreamContext *context);
     };
 
     /// @brief IOStream Class wrapper for CStream.
@@ -162,10 +162,10 @@ namespace c2pa
         ~CppIOStream();
 
     private:
-        static size_t reader(StreamContext *context, void *buffer, size_t size);
-        static int writer(StreamContext *context, const void *buffer, int size);
-        static long seeker(StreamContext *context, long int offset, int whence);
-        static int flusher(StreamContext *context);
+        static intptr_t reader(StreamContext *context, uint8_t *buffer, intptr_t size);
+        static intptr_t writer(StreamContext *context, const uint8_t *buffer, intptr_t size);
+        static intptr_t seeker(StreamContext *context, intptr_t offset, C2paSeekMode whence);
+        static intptr_t flusher(StreamContext *context);
     };
 
     /// @brief Reader class for reading a manifest.

--- a/src/c2pa.cpp
+++ b/src/c2pa.cpp
@@ -88,7 +88,7 @@ namespace c2pa
 
         char *result = c2pa_read_file(source_path.u8string().c_str(), dir);
 
-		if (result == nullptr)
+        if (result == nullptr)
         {
             auto exception = c2pa::Exception();
             if (strstr(exception.what(), "ManifestNotFound") != NULL)
@@ -151,10 +151,10 @@ namespace c2pa
     template <typename IStream>
     CppIStream::CppIStream(IStream &istream) : CStream()
     {
-        static_assert (std::is_base_of<std::istream, IStream>::value,
-                       "Stream must be derived from std::istream");
+        static_assert(std::is_base_of<std::istream, IStream>::value,
+                      "Stream must be derived from std::istream");
 
-        c_stream = c2pa_create_stream(reinterpret_cast<StreamContext *>(&istream), (ReadCallback)reader, (SeekCallback)seeker, (WriteCallback)writer, (FlushCallback)flusher);
+        c_stream = c2pa_create_stream(reinterpret_cast<StreamContext *>(&istream), reader, seeker, writer, flusher);
     }
 
     CppIStream::~CppIStream()
@@ -162,7 +162,7 @@ namespace c2pa
         c2pa_release_stream(c_stream);
     }
 
-    size_t CppIStream::reader(StreamContext *context, void *buffer, size_t size)
+    intptr_t CppIStream::reader(StreamContext *context, uint8_t *buffer, intptr_t size)
     {
         std::istream *istream = (std::istream *)context;
         istream->read((char *)buffer, size);
@@ -185,20 +185,20 @@ namespace c2pa
         return gcount;
     }
 
-    long CppIStream::seeker(StreamContext *context, long int offset, int whence)
+    intptr_t CppIStream::seeker(StreamContext *context, intptr_t offset, C2paSeekMode whence)
     {
         std::istream *istream = (std::istream *)context;
 
         std::ios_base::seekdir dir = std::ios_base::beg;
         switch (whence)
         {
-        case SEEK_SET:
+        case C2paSeekMode::Start:
             dir = std::ios_base::beg;
             break;
-        case SEEK_CUR:
+        case C2paSeekMode::Current:
             dir = std::ios_base::cur;
             break;
-        case SEEK_END:
+        case C2paSeekMode::End:
             dir = std::ios_base::end;
             break;
         };
@@ -215,7 +215,7 @@ namespace c2pa
             errno = EIO;
             return -1;
         }
-        long pos = (long) istream->tellg();
+        long pos = (long)istream->tellg();
         if (pos < 0)
         {
             errno = EIO;
@@ -225,7 +225,7 @@ namespace c2pa
         return pos;
     }
 
-    int CppIStream::writer(StreamContext *context, const void *buffer, int size)
+    intptr_t CppIStream::writer(StreamContext *context, const uint8_t *buffer, intptr_t size)
     {
         std::iostream *iostream = (std::iostream *)context;
         iostream->write((const char *)buffer, size);
@@ -242,7 +242,7 @@ namespace c2pa
         return size;
     }
 
-    int CppIStream::flusher(StreamContext *context)
+    intptr_t CppIStream::flusher(StreamContext *context)
     {
         std::iostream *iostream = (std::iostream *)context;
         iostream->flush();
@@ -255,7 +255,7 @@ namespace c2pa
     CppOStream::CppOStream(OStream &ostream) : CStream()
     {
         static_assert(std::is_base_of<std::ostream, OStream>::value, "Stream must be derived from std::ostream");
-        c_stream = c2pa_create_stream(reinterpret_cast<StreamContext *>(&ostream), (ReadCallback)reader, (SeekCallback)seeker, (WriteCallback)writer, (FlushCallback)flusher);
+        c_stream = c2pa_create_stream(reinterpret_cast<StreamContext *>(&ostream), reader, seeker, writer, flusher);
     }
 
     CppOStream::~CppOStream()
@@ -263,13 +263,13 @@ namespace c2pa
         c2pa_release_stream(c_stream);
     }
 
-    size_t CppOStream::reader(StreamContext *context, void *buffer, size_t size)
+    intptr_t CppOStream::reader(StreamContext *context, uint8_t *buffer, intptr_t size)
     {
         errno = EINVAL; // Invalid argument
         return -1;
     }
 
-    long CppOStream::seeker(StreamContext *context, long int offset, int whence)
+    intptr_t CppOStream::seeker(StreamContext *context, intptr_t offset, C2paSeekMode whence)
     {
         std::ostream *ostream = (std::ostream *)context;
         // printf("seeker ofstream = %p\n", ostream);
@@ -306,7 +306,7 @@ namespace c2pa
             errno = EIO; // Input/output error
             return -1;
         }
-        long pos = (long) ostream->tellp();
+        long pos = (long)ostream->tellp();
         if (pos < 0)
         {
             errno = EIO; // Input/output error
@@ -315,7 +315,7 @@ namespace c2pa
         return pos;
     }
 
-    int CppOStream::writer(StreamContext *context, const void *buffer, int size)
+    intptr_t CppOStream::writer(StreamContext *context, const uint8_t *buffer, intptr_t size)
     {
         std::ostream *ofstream = (std::ostream *)context;
         // printf("writer ofstream = %p\n", ofstream);
@@ -333,7 +333,7 @@ namespace c2pa
         return size;
     }
 
-    int CppOStream::flusher(StreamContext *context)
+    intptr_t CppOStream::flusher(StreamContext *context)
     {
         std::ofstream *ofstream = (std::ofstream *)context;
         ofstream->flush();
@@ -345,14 +345,14 @@ namespace c2pa
     CppIOStream::CppIOStream(IOStream &iostream)
     {
         static_assert(std::is_base_of<std::iostream, IOStream>::value, "Stream must be derived from std::iostream");
-        c_stream = c2pa_create_stream(reinterpret_cast<StreamContext *>(&iostream), (ReadCallback)reader, (SeekCallback)seeker, (WriteCallback)writer, (FlushCallback)flusher);
+        c_stream = c2pa_create_stream(reinterpret_cast<StreamContext *>(&iostream), reader, seeker, writer, flusher);
     }
     CppIOStream::~CppIOStream()
     {
         c2pa_release_stream(c_stream);
     }
 
-    size_t CppIOStream::reader(StreamContext *context, void *buffer, size_t size)
+    intptr_t CppIOStream::reader(StreamContext *context, uint8_t *buffer, intptr_t size)
     {
         std::iostream *iostream = (std::iostream *)context;
         iostream->read((char *)buffer, size);
@@ -375,7 +375,7 @@ namespace c2pa
         return gcount;
     }
 
-    long CppIOStream::seeker(StreamContext *context, long int offset, int whence)
+    intptr_t CppIOStream::seeker(StreamContext *context, intptr_t offset, C2paSeekMode whence)
     {
         iostream *iostream = (std::iostream *)context;
 
@@ -412,7 +412,7 @@ namespace c2pa
             errno = EIO; // Input/output error
             return -1;
         }
-        long pos = (long) iostream->tellg();
+        long pos = (long)iostream->tellg();
         if (pos < 0)
         {
             errno = EIO; // Input/output error
@@ -430,7 +430,7 @@ namespace c2pa
             errno = EIO; // Input/output error
             return -1;
         }
-        pos = (long) iostream->tellp();
+        pos = (long)iostream->tellp();
         if (pos < 0)
         {
             errno = EIO; // Input/output error
@@ -439,7 +439,7 @@ namespace c2pa
         return pos;
     }
 
-    int CppIOStream::writer(StreamContext *context, const void *buffer, int size)
+    intptr_t CppIOStream::writer(StreamContext *context, const uint8_t *buffer, intptr_t size)
     {
         std::iostream *iostream = (std::iostream *)context;
         iostream->write((const char *)buffer, size);
@@ -456,7 +456,7 @@ namespace c2pa
         return size;
     }
 
-    int CppIOStream::flusher(StreamContext *context)
+    intptr_t CppIOStream::flusher(StreamContext *context)
     {
         std::iostream *iostream = (std::iostream *)context;
         iostream->flush();
@@ -555,7 +555,7 @@ namespace c2pa
         catch (std::exception const &e)
         {
             // todo pass exceptions to Rust error handling
-			(void) e;
+            (void)e;
             // printf("Error: signer_passthrough - %s\n", e.what());
             return -1;
         }
@@ -790,15 +790,18 @@ namespace c2pa
     {
         int result;
         const unsigned char *c2pa_manifest_bytes = NULL;
-        if (asset) {
+        if (asset)
+        {
             CppIStream c_asset(*asset);
             result = c2pa_builder_sign_data_hashed_embeddable(builder, signer.c2pa_signer(), data_hash.c_str(), format.c_str(), c_asset.c_stream, &c2pa_manifest_bytes);
-        } else {
+        }
+        else
+        {
             result = c2pa_builder_sign_data_hashed_embeddable(builder, signer.c2pa_signer(), data_hash.c_str(), format.c_str(), nullptr, &c2pa_manifest_bytes);
         }
         if (result < 0 || c2pa_manifest_bytes == NULL)
         {
-          throw(c2pa::Exception("Failed to create data hashed placeholder"));
+            throw(c2pa::Exception("Failed to create data hashed placeholder"));
         }
 
         auto data = std::vector<unsigned char>(c2pa_manifest_bytes, c2pa_manifest_bytes + result);

--- a/tests/file_stream.h
+++ b/tests/file_stream.h
@@ -20,7 +20,7 @@
 #include <errno.h>
 #include "../include/c2pa.h"
 
-ssize_t reader(size_t context, uint8_t *data, size_t len)
+intptr_t reader(StreamContext *context, uint8_t *data, intptr_t len)
 {
     // printf("reader: context = %0lx, data = %p, len = %zu\n", context, data, len);
     size_t count = fread(data, 1, len, (FILE *)context);
@@ -38,7 +38,7 @@ ssize_t reader(size_t context, uint8_t *data, size_t len)
     return count;
 }
 
-long seeker(size_t context, long int offset, int whence)
+intptr_t seeker(StreamContext *context, intptr_t offset, C2paSeekMode whence)
 {
 
     // printf("seeker: context = %0lx, offset = %ld, whence = %d\n", context, offset, whence);
@@ -53,7 +53,7 @@ long seeker(size_t context, long int offset, int whence)
     return ftell((FILE *)context);
 }
 
-ssize_t writer(size_t context, uint8_t *data, size_t len)
+intptr_t writer(StreamContext *context, const uint8_t *data, intptr_t len)
 {
     // printf("writer: context = %zu, data = %p, len = %zu\n", context, data, len);
     size_t count = fwrite(data, 1, len, (FILE *)context);
@@ -69,7 +69,7 @@ ssize_t writer(size_t context, uint8_t *data, size_t len)
     return count;
 }
 
-ssize_t flusher(size_t context)
+intptr_t flusher(StreamContext *context)
 {
     // printf("flusher: context = %zu\n", context);
     int result = fflush((FILE *)context);
@@ -85,7 +85,7 @@ CStream *create_file_stream(FILE *file)
 {
     if (file != NULL)
     {
-        return c2pa_create_stream((StreamContext *)file, (ReadCallback)reader, (SeekCallback)seeker, (WriteCallback)writer, (FlushCallback)flusher);
+        return c2pa_create_stream((StreamContext *)file, reader, seeker, writer, flusher);
     }
     return NULL;
 }


### PR DESCRIPTION
Updates Stream callbacks to use consistent uintptr_t values
Adds C2paSeekMode enum
corrects the use of path strings on Windows builds.