### PR TITLE
feat: add Builder::format_embeddable()

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "c2pa-c"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 authors = ["Gavin Peacock <gpeacock@adobe.com"]
 

--- a/include/c2pa.h
+++ b/include/c2pa.h
@@ -576,6 +576,34 @@ int c2pa_builder_sign_data_hashed_embeddable(struct C2paBuilder *builder_ptr,
                                              const unsigned char **manifest_bytes_ptr);
 
 /**
+ * Convert a binary c2pa manifest into an embeddable version for the given format.
+ * A raw manifest (in application/c2pa format) can be uploaded to the cloud but
+ * it cannot be embedded directly into an asset without extra processing.
+ * This method converts the raw manifest into an embeddable version that can be
+ * embedded into an asset.
+ *
+ * # Parameters
+ * * format: pointer to a C string with the mime type or extension.
+ * * manifest_bytes_ptr: pointer to a c_uchar with the raw manifest bytes.
+ * * manifest_bytes_size: the size of the manifest_bytes.
+ * * result_bytes_ptr: pointer to a pointer to a c_uchar to return the embeddable manifest bytes.
+ *
+ * # Errors
+ * Returns -1 if there were errors, otherwise returns the size of the result_bytes.
+ * The error string can be retrieved by calling c2pa_error.
+ *
+ * # Safety
+ * Reads from NULL-terminated C strings.
+ * The returned value MUST be released by calling c2pa_manifest_bytes_free
+ * and it is no longer valid after that call.
+ */
+IMPORT extern
+int c2pa_format_embeddable(const char *format,
+                           const unsigned char *manifest_bytes_ptr,
+                           uintptr_t manifest_bytes_size,
+                           const unsigned char **result_bytes_ptr);
+
+/**
  * Creates a C2paSigner from a callback and configuration.
  *
  * # Parameters

--- a/include/c2pa.hpp
+++ b/include/c2pa.hpp
@@ -330,19 +330,25 @@ namespace c2pa
 
         /// @brief Create a hashed placeholder from the builder.
         /// @param reserved_size  The size required for a signature from the intended signer.
-        /// @param format  The format of the mime type or extension.
+        /// @param format  The format of the mime type or extension of the asset.
         /// @return A vector containing the hashed placeholder.
         /// @throws C2pa::Exception for errors encountered by the C2PA library.
         std::vector<unsigned char> data_hashed_placeholder(uintptr_t reserved_size, const string &format);
 
         /// @brief Sign a Builder using the specified signer and data hash.
         /// @param signer  The signer to use for signing.
-        /// @param data_hash  The data hash to sign.
-        /// @param format  The format of the data hash.
+        /// @param data_hash  The data hash ranges to sign. This must contain hashes unless and asset is provided.
+        /// @param format  The mime format for embedding into.  Use "c2pa" for an unformatted result.
         /// @param asset  An optional asset to hash according to the data_hash information.
         /// @return A vector containing the signed data.
         /// @throws C2pa::Exception for errors encountered by the C2PA library.
         std::vector<unsigned char> sign_data_hashed_embeddable(Signer &signer, const string &data_hash, const string &format, istream *asset = nullptr);
+
+        /// @brief convert an unformatted manifest data to an embeddable format.
+        /// @param format The format for embedding into.
+        /// @param data An unformatted manifest data block from sign_data_hashed_embeddable using "c2pa" format.
+        /// @return A formatted copy of the data.
+        static std::vector<unsigned char> format_embeddable(const string &format, std::vector<unsigned char> &data);
 
     private:
         // Private constructor for Builder from an archive (todo: find a better way to handle this)

--- a/src/c2pa.cpp
+++ b/src/c2pa.cpp
@@ -778,7 +778,7 @@ namespace c2pa
         auto result = c2pa_builder_data_hashed_placeholder(builder, reserve_size, format.c_str(), &c2pa_manifest_bytes);
         if (result < 0 || c2pa_manifest_bytes == NULL)
         {
-            throw(c2pa::Exception("Failed to create data hashed placeholder"));
+            throw(Exception());
         }
 
         auto data = std::vector<unsigned char>(c2pa_manifest_bytes, c2pa_manifest_bytes + result);
@@ -801,7 +801,7 @@ namespace c2pa
         }
         if (result < 0 || c2pa_manifest_bytes == NULL)
         {
-            throw(c2pa::Exception("Failed to create data hashed placeholder"));
+            throw(Exception());
         }
 
         auto data = std::vector<unsigned char>(c2pa_manifest_bytes, c2pa_manifest_bytes + result);
@@ -815,7 +815,7 @@ namespace c2pa
         auto result = c2pa_format_embeddable(format.c_str(), data.data(), data.size(), &c2pa_manifest_bytes);
         if (result < 0 || c2pa_manifest_bytes == NULL)
         {
-            throw(c2pa::Exception("Failed to create data hashed placeholder"));
+            throw(Exception());
         }
 
         auto formatted_data = std::vector<unsigned char>(c2pa_manifest_bytes, c2pa_manifest_bytes + result);

--- a/src/c2pa.cpp
+++ b/src/c2pa.cpp
@@ -808,4 +808,18 @@ namespace c2pa
         c2pa_manifest_bytes_free(c2pa_manifest_bytes);
         return data;
     }
+
+    std::vector<unsigned char> Builder::format_embeddable(const string &format, std::vector<unsigned char> &data)
+    {
+        const unsigned char *c2pa_manifest_bytes = NULL;
+        auto result = c2pa_format_embeddable(format.c_str(), data.data(), data.size(), &c2pa_manifest_bytes);
+        if (result < 0 || c2pa_manifest_bytes == NULL)
+        {
+            throw(c2pa::Exception("Failed to create data hashed placeholder"));
+        }
+
+        auto formatted_data = std::vector<unsigned char>(c2pa_manifest_bytes, c2pa_manifest_bytes + result);
+        c2pa_manifest_bytes_free(c2pa_manifest_bytes);
+        return formatted_data;
+    }
 } // namespace c2pa

--- a/tests/builder.test.cpp
+++ b/tests/builder.test.cpp
@@ -248,11 +248,14 @@ TEST(Builder, SignDataHashedEmbeddedWithAsset)
             FAIL() << "Failed to open file: " << image_path << std::endl;
         }
 
-        auto manifest_data = builder.sign_data_hashed_embeddable(signer, data_hash, "image/jpeg", &asset);
+        auto manifest_data = builder.sign_data_hashed_embeddable(signer, data_hash, "application/c2pa", &asset);
+
+        auto embeddable_data = c2pa::Builder::format_embeddable("image/jpeg", manifest_data);
+
+        ASSERT_TRUE(embeddable_data.size() > manifest_data.size());
     }
     catch (c2pa::Exception const &e)
     {
         FAIL() << "Failed: C2pa::Builder: " << e.what() << endl;
     };
 }
-


### PR DESCRIPTION
Allows formatting a manifest for embedding after uploading to cloud.