### PR TITLE
fix: Use ios_base::binary for cpp get_resource and return int64_t

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "c2pa-c"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 authors = ["Gavin Peacock <gpeacock@adobe.com"]
 

--- a/Makefile
+++ b/Makefile
@@ -44,9 +44,10 @@ test-c: release
 	$(ENV) target/release/ctest
 
 test-cpp: release cmake
-	cd $(BUILD_DIR); ninja;
-	cd $(BUILD_DIR); ls -lah src
-	cd $(BUILD_DIR); ./src/c2pa_c_tests
+	cd $(BUILD_DIR) && ninja
+	mkdir -p $(BUILD_DIR)/src/tests/fixtures
+	cp -r tests/fixtures/* $(BUILD_DIR)/src/tests/fixtures/
+	cd $(BUILD_DIR)/src && $(ENV) ./c2pa_c_tests
 
 demo: cmake release
 	cmake --build ./$(BUILD_DIR) --target demo

--- a/Makefile
+++ b/Makefile
@@ -69,4 +69,4 @@ package:
 
 test: test-rust test-cpp 
 
-all: unit-tests examples
+all: test examples

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ ifeq ($(findstring _NT, $(OS)), _NT)
 CFLAGS += -L./target/release -lc2pa_c
 CC := gcc
 CXX := g++
+ENV = PATH="$(shell pwd)/target/release:$(PATH)"
 endif
 ifeq ($(OS), Darwin)
 CFLAGS += -framework Security
@@ -47,10 +48,11 @@ test-cpp: release cmake
 	mkdir -p $(BUILD_DIR)/src/tests/fixtures
 	cp -r tests/fixtures/* $(BUILD_DIR)/src/tests/fixtures/
 ifeq ($(findstring _NT, $(OS)), _NT)
-	@if not exist target\\release\\c2pa_c.dll (echo DLL not found && exit 1)
-	if not exist $(BUILD_DIR)\\src mkdir $(BUILD_DIR)\\src
-	copy /Y target\\release\\c2pa_c.dll $(BUILD_DIR)\\src\\c2pa_c.dll
-	cd $(BUILD_DIR)\\src && $(ENV) .\\c2pa_c_tests
+	@echo "Current directory: $$(pwd)"
+	@echo "DLL location: $$(pwd)/target/release/c2pa_c.dll"
+	@echo "Test exe location: $$(pwd)/$(BUILD_DIR)/src/c2pa_c_tests.exe"
+	cp target/release/c2pa_c.dll $(BUILD_DIR)/src/
+	cd $(BUILD_DIR)/src && $(ENV) cmd /c "set PATH=$$(pwd);%PATH% && c2pa_c_tests.exe"
 else
 	cd $(BUILD_DIR)/src && $(ENV) ./c2pa_c_tests
 endif

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,6 @@ ifeq ($(findstring _NT, $(OS)), _NT)
 CFLAGS += -L./target/release -lc2pa_c
 CC := gcc
 CXX := g++
-ENV = LD_LIBRARY_PATH=target/release
 endif
 ifeq ($(OS), Darwin)
 CFLAGS += -framework Security
@@ -47,7 +46,14 @@ test-cpp: release cmake
 	cd $(BUILD_DIR) && ninja
 	mkdir -p $(BUILD_DIR)/src/tests/fixtures
 	cp -r tests/fixtures/* $(BUILD_DIR)/src/tests/fixtures/
+ifeq ($(findstring _NT, $(OS)), _NT)
+	@if not exist target\\release\\c2pa_c.dll (echo DLL not found && exit 1)
+	if not exist $(BUILD_DIR)\\src mkdir $(BUILD_DIR)\\src
+	copy /Y target\\release\\c2pa_c.dll $(BUILD_DIR)\\src\\c2pa_c.dll
+	cd $(BUILD_DIR)\\src && $(ENV) .\\c2pa_c_tests
+else
 	cd $(BUILD_DIR)/src && $(ENV) ./c2pa_c_tests
+endif
 
 demo: cmake release
 	cmake --build ./$(BUILD_DIR) --target demo

--- a/deny.toml
+++ b/deny.toml
@@ -19,6 +19,7 @@ ignore = [
     "RUSTSEC-2021-0127", # serde_cbor
     "RUSTSEC-2023-0071", # rsa Marvin Attack: (https://jira.corp.adobe.com/browse/CAI-5104)
     "RUSTSEC-2024-0384", # instant (https://github.com/contentauth/c2pa-rs/issues/663)
+    "RUSTSEC-2025-0009", # ring
     "RUSTSEC-2025-0010", # ring
 ]
 

--- a/deny.toml
+++ b/deny.toml
@@ -19,7 +19,7 @@ ignore = [
     "RUSTSEC-2021-0127", # serde_cbor
     "RUSTSEC-2023-0071", # rsa Marvin Attack: (https://jira.corp.adobe.com/browse/CAI-5104)
     "RUSTSEC-2024-0384", # instant (https://github.com/contentauth/c2pa-rs/issues/663)
-    "RUSTSEC-2025-0009", # ring
+    "RUSTSEC-2025-0010", # ring
 ]
 
 [bans]

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,22 +1,22 @@
-# # Set the minimum required version of CMake
-# cmake_minimum_required(VERSION 3.27)
+# Set the minimum required version of CMake
+cmake_minimum_required(VERSION 3.27)
 
-# # install json
-# FetchContent_Declare(json URL https://github.com/nlohmann/json/releases/download/v3.11.3/json.tar.xz)
-# FetchContent_MakeAvailable(json)
+# install json
+FetchContent_Declare(json URL https://github.com/nlohmann/json/releases/download/v3.11.3/json.tar.xz)
+FetchContent_MakeAvailable(json)
 
-# # Set the project name
-# project(Examples)
+# Set the project name
+project(Examples)
 
-# # Include the directory containing the main project headers
-# include_directories(${CMAKE_SOURCE_DIR}/include)
-# include_directories(${CMAKE_SOURCE_DIR}/tests)
+# Include the directory containing the main project headers
+include_directories(${CMAKE_SOURCE_DIR}/include)
+include_directories(${CMAKE_SOURCE_DIR}/tests)
 
-# # Add example1 executable
-# add_executable(training training.cpp)
-# target_link_libraries(training nlohmann_json::nlohmann_json)
-# target_link_libraries(training c2pa_cpp)
+# Add example1 executable
+add_executable(training training.cpp)
+target_link_libraries(training nlohmann_json::nlohmann_json)
+target_link_libraries(training c2pa_cpp)
 
-# add_executable(demo demo.cpp)
-# target_link_libraries(demo nlohmann_json::nlohmann_json)
-# target_link_libraries(demo c2pa_cpp)
+add_executable(demo demo.cpp)
+target_link_libraries(demo nlohmann_json::nlohmann_json)
+target_link_libraries(demo c2pa_cpp)

--- a/examples/training.cpp
+++ b/examples/training.cpp
@@ -55,12 +55,13 @@ int main()
 {
     // Get the current directory of this file
     fs::path current_dir = get_current_directory(__FILE__);
+    fs::path project_root = current_dir.parent_path(); // Go up one level to project root
 
-    // Construct the paths relative to the current directory
-    fs::path manifest_path = current_dir / "../tests/fixtures/training.json";
-    fs::path certs_path = current_dir / "../tests/fixtures/ed25519_certs.pem";
-    fs::path image_path = current_dir / "../tests/fixtures/A.jpg";
-    fs::path output_path = current_dir / "../target/example/training.jpg";
+    // Construct the paths relative to the project root
+    fs::path manifest_path = project_root / "tests/fixtures/training.json";
+    fs::path certs_path = project_root / "tests/fixtures/es256_certs.pem";
+    fs::path image_path = project_root / "tests/fixtures/A.jpg";
+    fs::path output_path = project_root / "target/example/training.jpg";
 
     cout << "The C2pa library version is " << c2pa::version() << endl;
     cout << "RUNNING EXAMPLE training.cpp " << endl;

--- a/include/c2pa.h
+++ b/include/c2pa.h
@@ -81,7 +81,7 @@ typedef struct C2paSigner C2paSigner;
  * An Opaque struct to hold a context value for the stream callbacks
  */
 typedef struct StreamContext {
-  uint8_t _private[0];
+
 } StreamContext;
 
 /**
@@ -148,11 +148,11 @@ typedef struct C2paSignerInfo {
 } C2paSignerInfo;
 
 typedef struct C2paReader {
-  uint8_t _private[0];
+
 } C2paReader;
 
 typedef struct C2paBuilder {
-  uint8_t _private[0];
+
 } C2paBuilder;
 
 /**

--- a/include/c2pa.h
+++ b/include/c2pa.h
@@ -371,9 +371,9 @@ C2PA_API extern char *c2pa_reader_json(struct C2paReader *reader_ptr);
  *
  * # Example
  * ```c
- * result c2pa_reader_resource_to_stream(store, "uri", stream);
+ * auto result = c2pa_reader_resource_to_stream(store, "uri", stream);
  * if (result < 0) {
- *     let error = c2pa_error();
+ *     auto error = c2pa_error();
  *     printf("Error: %s\n", error);
  *     c2pa_string_free(error);
  * }
@@ -400,7 +400,7 @@ int64_t c2pa_reader_resource_to_stream(struct C2paReader *reader_ptr,
  * ```c
  * auto result = c2pa_builder_from_json(manifest_json);
  * if (result == NULL) {
- *     let error = c2pa_error();
+ *     auto error = c2pa_error();
  *     printf("Error: %s\n", error);
  *     c2pa_string_free(error);
  * }
@@ -424,7 +424,7 @@ C2PA_API extern struct C2paBuilder *c2pa_builder_from_json(const char *manifest_
  * ```c
  * auto result = c2pa_builder_from_archive(stream);
  * if (result == NULL) {
- *     let error = c2pa_error();
+ *     auto error = c2pa_error();
  *     printf("Error: %s\n", error);
  *     c2pa_string_free(error);
  * }
@@ -529,7 +529,7 @@ int c2pa_builder_add_ingredient_from_stream(struct C2paBuilder *builder_ptr,
  * ```c
  * auto result = c2pa_builder_to_archive(builder, stream);
  * if (result < 0) {
- *     let error = c2pa_error();
+ *     auto error = c2pa_error();
  *     printf("Error: %s\n", error);
  *     c2pa_string_free(error);
  * }
@@ -680,7 +680,7 @@ int64_t c2pa_format_embeddable(const char *format,
  * ```c
  * auto result = c2pa_signer_create(callback, alg, certs, tsa_url);
  * if (result == NULL) {
- *     let error = c2pa_error();
+ *     auto error = c2pa_error();
  *     printf("Error: %s\n", error);
  *     c2pa_string_free(error);
  * }
@@ -711,7 +711,7 @@ struct C2paSigner *c2pa_signer_create(const void *context,
  * ```c
  * auto result = c2pa_signer_from_info(signer_info);
  * if (result == NULL) {
- *     let error = c2pa_error();
+ *     auto error = c2pa_error();
  *     printf("Error: %s\n", error);
  *     c2pa_string_free(error);
  * }

--- a/include/c2pa.hpp
+++ b/include/c2pa.hpp
@@ -194,14 +194,14 @@ namespace c2pa
         /// @param path The path to write the resource to.
         /// @return The number of bytes written.
         /// @throws C2pa::C2paException for errors encountered by the C2PA library.
-        int get_resource(const string &uri, const std::filesystem::path &path);
+        int64_t get_resource(const string &uri, const std::filesystem::path &path);
 
         /// @brief  Get a resource from the reader  and write it to an output stream.
         /// @param uri The uri of the resource.
         /// @param stream The output stream to write the resource to.
         /// @return The number of bytes written.
         /// @throws C2pa::C2paException for errors encountered by the C2PA library.
-        int get_resource(const string &uri, std::ostream &stream);
+        int64_t get_resource(const string &uri, std::ostream &stream);
     };
 
     /// @brief  Signer Callback function type.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -55,15 +55,16 @@ elseif(WIN32)
     ${CMAKE_SOURCE_DIR}/target/release/c2pa_c.dll.lib
   )
 
-  target_link_libraries(c2pa_cpp
-    ${CMAKE_SOURCE_DIR}/target/release/c2pa_c.dll.lib
-  )
-
+  # Copy DLL to the test executable directory
   add_custom_command(TARGET c2pa_c_tests POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E copy_if_different
-    "${CMAKE_SOURCE_DIR}/target/release/c2pa_c.dll"
-    $<TARGET_FILE_DIR:c2pa_c_tests>
-    COMMENT "Copying required c2pa_c.dll to executing directory of tests."
+      "${CMAKE_SOURCE_DIR}/target/release/c2pa_c.dll"
+      $<TARGET_FILE_DIR:c2pa_c_tests>
+    COMMENT "Copying c2pa_c.dll to test executable directory"
+  )
+
+  target_link_libraries(c2pa_cpp
+    ${CMAKE_SOURCE_DIR}/target/release/c2pa_c.dll.lib
   )
 else()
   target_link_libraries(c2pa_cpp

--- a/src/c2pa.cpp
+++ b/src/c2pa.cpp
@@ -516,7 +516,7 @@ namespace c2pa
         return str;
     }
 
-    int Reader::get_resource(const string &uri, const std::filesystem::path &path)
+    int64_t Reader::get_resource(const string &uri, const std::filesystem::path &path)
     {
         std::ofstream file_stream(path, std::ios::binary);
         if (!file_stream.is_open())
@@ -526,10 +526,10 @@ namespace c2pa
         return get_resource(uri.c_str(), file_stream);
     }
 
-    int Reader::get_resource(const string &uri, std::ostream &stream)
+    int64_t Reader::get_resource(const string &uri, std::ostream &stream)
     {
         CppOStream cpp_stream(stream);
-        int result = c2pa_reader_resource_to_stream(c2pa_reader, uri.c_str(), cpp_stream.c_stream);
+        int64_t result = c2pa_reader_resource_to_stream(c2pa_reader, uri.c_str(), cpp_stream.c_stream);
         if (result < 0)
         {
             throw C2paException();
@@ -794,7 +794,7 @@ namespace c2pa
 
     std::vector<unsigned char> Builder::sign_data_hashed_embeddable(Signer &signer, const string &data_hash, const string &format, istream *asset)
     {
-        int result;
+        int64_t result;
         const unsigned char *c2pa_manifest_bytes = NULL;
         if (asset)
         {

--- a/src/c2pa.cpp
+++ b/src/c2pa.cpp
@@ -475,7 +475,7 @@ namespace c2pa
 
     Reader::Reader(const std::filesystem::path &source_path)
     {
-        std::ifstream file_stream(source_path, std::ios::binary);
+        std::ifstream file_stream(source_path, std::ios_base::binary);
         if (!file_stream.is_open())
         {
             throw C2paException("Failed to open file: " + source_path.string() + " - " + std::strerror(errno));
@@ -518,7 +518,7 @@ namespace c2pa
 
     int64_t Reader::get_resource(const string &uri, const std::filesystem::path &path)
     {
-        std::ofstream file_stream(path, std::ios::binary);
+        std::ofstream file_stream(path, std::ios_base::binary);
         if (!file_stream.is_open())
         {
             throw C2paException(); // Handle file open error appropriately
@@ -574,7 +574,7 @@ namespace c2pa
 
     Signer::Signer(const string &alg, const string &sign_cert, const string &private_key, const string &tsa_uri)
     {
-        auto info = C2paSignerInfo {.alg = alg.c_str(), .sign_cert = sign_cert.c_str(), .private_key = private_key.c_str(), .ta_url = tsa_uri.c_str()};
+        auto info = C2paSignerInfo { alg.c_str(), sign_cert.c_str(), private_key.c_str(), tsa_uri.c_str()};
         signer = c2pa_signer_from_info(&info);
     }
 
@@ -649,7 +649,7 @@ namespace c2pa
 
     void Builder::add_resource(const string &uri, const std::filesystem::path &source_path)
     {
-        ifstream stream = ifstream(source_path);
+        ifstream stream = ifstream(source_path, std::ios_base::binary);
         if (!stream.is_open())
         {
             throw std::runtime_error("Failed to open source file: " + source_path.string());
@@ -669,7 +669,7 @@ namespace c2pa
 
     void Builder::add_ingredient(const string &ingredient_json, const std::filesystem::path &source_path)
     {
-        ifstream stream = ifstream(source_path);
+        ifstream stream = ifstream(source_path, std::ios_base::binary);
         if (!stream.is_open())
         {
             throw std::runtime_error("Failed to open source file: " + source_path.string());
@@ -706,7 +706,7 @@ namespace c2pa
     /// @throws C2pa::C2paException for errors encountered by the C2PA library.
     std::vector<unsigned char> Builder::sign(const path &source_path, const path &dest_path, Signer &signer)
     {
-        std::ifstream source(source_path, std::ios::binary);
+        std::ifstream source(source_path, std::ios_base::binary);
         if (!source.is_open())
         {
             throw std::runtime_error("Failed to open source file: " + source_path.string());
@@ -717,7 +717,7 @@ namespace c2pa
         {
             std::filesystem::create_directories(dest_dir);
         }
-        std::ofstream dest(dest_path, std::ios::binary);
+        std::ofstream dest(dest_path, std::ios_base::binary);
         if (!dest.is_open())
         {
             throw std::runtime_error("Failed to open destination file: " + dest_path.string());
@@ -744,7 +744,7 @@ namespace c2pa
     /// @throws C2pa::C2paException for errors encountered by the C2PA library.
     Builder Builder::from_archive(const path &archive_path)
     {
-        std::ifstream path(archive_path, std::ios::binary);
+        std::ifstream path(archive_path, std::ios_base::binary);
         if (!path.is_open())
         {
             throw std::runtime_error("Failed to open archive file: " + archive_path.string());
@@ -770,7 +770,7 @@ namespace c2pa
     /// @throws C2pa::C2paException for errors encountered by the C2PA library.
     void Builder::to_archive(const path &dest_path)
     {
-        std::ofstream dest(dest_path, std::ios::binary);
+        std::ofstream dest(dest_path, std::ios_base::binary);
         if (!dest.is_open())
         {
             throw std::runtime_error("Failed to open destination file: " + dest_path.string());

--- a/src/c2pa_stream.rs
+++ b/src/c2pa_stream.rs
@@ -21,9 +21,7 @@ use crate::Error;
 #[repr(C)]
 #[derive(Debug)]
 /// An Opaque struct to hold a context value for the stream callbacks
-pub struct StreamContext {
-    _private: [u8; 0],
-}
+pub struct StreamContext;
 
 #[repr(C)]
 #[derive(Debug)]
@@ -97,7 +95,7 @@ impl C2paStream {
 
     /// Extracts the context from the C2paStream (used for testing in Rust)
     pub fn extract_context(&mut self) -> Box<StreamContext> {
-        std::mem::replace(&mut self.context, Box::new(StreamContext { _private: [] }))
+        std::mem::replace(&mut self.context, Box::new(StreamContext {}))
     }
 }
 

--- a/src/c_api.rs
+++ b/src/c_api.rs
@@ -33,15 +33,11 @@ use crate::{
 mod cbindgen_fix {
     #[repr(C)]
     #[allow(dead_code)]
-    pub struct C2paBuilder {
-        _private: [u8; 0],
-    }
+    pub struct C2paBuilder;
 
     #[repr(C)]
     #[allow(dead_code)]
-    pub struct C2paReader {
-        _private: [u8; 0],
-    }
+    pub struct C2paReader;
 }
 
 /// List of supported signing algorithms.

--- a/src/c_api.rs
+++ b/src/c_api.rs
@@ -447,9 +447,9 @@ pub unsafe extern "C" fn c2pa_reader_json(reader_ptr: *mut C2paReader) -> *mut c
 ///
 /// # Example
 /// ```c
-/// result c2pa_reader_resource_to_stream(store, "uri", stream);
+/// auto result = c2pa_reader_resource_to_stream(store, "uri", stream);
 /// if (result < 0) {
-///     let error = c2pa_error();
+///     auto error = c2pa_error();
 ///     printf("Error: %s\n", error);
 ///     c2pa_string_free(error);
 /// }
@@ -488,7 +488,7 @@ pub unsafe extern "C" fn c2pa_reader_resource_to_stream(
 /// ```c
 /// auto result = c2pa_builder_from_json(manifest_json);
 /// if (result == NULL) {
-///     let error = c2pa_error();
+///     auto error = c2pa_error();
 ///     printf("Error: %s\n", error);
 ///     c2pa_string_free(error);
 /// }
@@ -521,7 +521,7 @@ pub unsafe extern "C" fn c2pa_builder_from_json(manifest_json: *const c_char) ->
 /// ```c
 /// auto result = c2pa_builder_from_archive(stream);
 /// if (result == NULL) {
-///     let error = c2pa_error();
+///     auto error = c2pa_error();
 ///     printf("Error: %s\n", error);
 ///     c2pa_string_free(error);
 /// }
@@ -675,7 +675,7 @@ pub unsafe extern "C" fn c2pa_builder_add_ingredient_from_stream(
 /// ```c
 /// auto result = c2pa_builder_to_archive(builder, stream);
 /// if (result < 0) {
-///     let error = c2pa_error();
+///     auto error = c2pa_error();
 ///     printf("Error: %s\n", error);
 ///     c2pa_string_free(error);
 /// }
@@ -953,7 +953,7 @@ pub unsafe extern "C" fn c2pa_format_embeddable(
 /// ```c
 /// auto result = c2pa_signer_create(callback, alg, certs, tsa_url);
 /// if (result == NULL) {
-///     let error = c2pa_error();
+///     auto error = c2pa_error();
 ///     printf("Error: %s\n", error);
 ///     c2pa_string_free(error);
 /// }
@@ -1017,7 +1017,7 @@ pub unsafe extern "C" fn c2pa_signer_create(
 /// ```c
 /// auto result = c2pa_signer_from_info(signer_info);
 /// if (result == NULL) {
-///     let error = c2pa_error();
+///     auto error = c2pa_error();
 ///     printf("Error: %s\n", error);
 ///     c2pa_string_free(error);
 /// }

--- a/tests/read_file.test.cpp
+++ b/tests/read_file.test.cpp
@@ -13,16 +13,22 @@
 #include <c2pa.hpp>
 #include <gtest/gtest.h>
 #include <nlohmann/json.hpp>
+#include <filesystem>
 
 using nlohmann::json;
+namespace fs = std::filesystem;
 
 TEST(ReadFile, ReadFileWithNoManifestReturnsEmptyOptional) {
-  auto result = c2pa::read_file("../../tests/fixtures/A.jpg");
-  ASSERT_TRUE(result->empty());
+  fs::path current_dir = fs::path(__FILE__).parent_path();
+  fs::path test_file = current_dir / "../tests/fixtures/A.jpg";
+  auto result = c2pa::read_file(test_file);
+  ASSERT_FALSE(result.has_value());
 };
 
 TEST(ReadFile, ReadFileWithManifestReturnsSomeValue) {
-  auto result = c2pa::read_file("../../tests/fixtures/C.jpg");
+  fs::path current_dir = fs::path(__FILE__).parent_path();
+  fs::path test_file = current_dir / "../tests/fixtures/C.jpg";
+  auto result = c2pa::read_file(test_file);
   ASSERT_TRUE(result.has_value());
 
   // parse result with json

--- a/tests/reader.test.cpp
+++ b/tests/reader.test.cpp
@@ -13,13 +13,20 @@
 #include <c2pa.hpp>
 #include <gtest/gtest.h>
 #include <nlohmann/json.hpp>
+#include <filesystem>
 
 using nlohmann::json;
+namespace fs = std::filesystem;
 
 TEST(Reader, StreamWithManifest)
 {
+    fs::path current_dir = fs::path(__FILE__).parent_path();
+    fs::path test_file = current_dir / "../tests/fixtures/C.jpg";
+    
     // read the new manifest and display the JSON
-    std::ifstream file_stream("../../tests/fixtures/C.jpg", std::ios::binary);
+    std::ifstream file_stream(test_file, std::ios::binary);
+    ASSERT_TRUE(file_stream.is_open()) << "Failed to open file: " << test_file;
+    
     auto reader = c2pa::Reader("image/jpeg", file_stream);
     auto manifest_store_json = reader.json();
     EXPECT_TRUE(manifest_store_json.find("C.jpg") != std::string::npos);
@@ -27,15 +34,20 @@ TEST(Reader, StreamWithManifest)
 
 TEST(Reader, FileWithManifest)
 {
+    fs::path current_dir = fs::path(__FILE__).parent_path();
+    fs::path test_file = current_dir / "../tests/fixtures/C.jpg";
+    
     // read the new manifest and display the JSON
-    auto reader = c2pa::Reader("../../tests/fixtures/C.jpg");
+    auto reader = c2pa::Reader(test_file);
     auto manifest_store_json = reader.json();
     EXPECT_TRUE(manifest_store_json.find("C.jpg") != std::string::npos);
 };
 
 TEST(Reader, FileNoManifest)
 {
-    EXPECT_THROW({ auto reader = c2pa::Reader("../../tests/fixtures/A.jpg"); }, c2pa::C2paException);
+    fs::path current_dir = fs::path(__FILE__).parent_path();
+    fs::path test_file = current_dir / "../tests/fixtures/A.jpg";
+    EXPECT_THROW({ auto reader = c2pa::Reader(test_file); }, c2pa::C2paException);
 };
 
 TEST(Reader, FileNotFound)
@@ -47,7 +59,6 @@ TEST(Reader, FileNotFound)
     }
     catch (const c2pa::C2paException &e)
     {
-        // EXPECT_STREQ(e.what(), "File not found");
         EXPECT_TRUE(std::string(e.what()).rfind("Failed to open file", 0) == 0);
     }
     catch (...)


### PR DESCRIPTION
Updates opaque structs C2paStream, C2paBuilder and C2paReader definitions.

