### PR TITLE
feat: Add Python goodies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@
 # Mac OS X files
 .DS_Store
 .idea
+
+# Python cache files
+tests/__pycache__/

--- a/tests/c2pa.py
+++ b/tests/c2pa.py
@@ -586,8 +586,10 @@ class Stream:
                     
                 # Ensure we don't write beyond the allocated memory
                 actual_length = min(len(buffer), length)
+                # Create a view of the buffer to avoid copying
+                buffer_view = (ctypes.c_ubyte * actual_length).from_buffer_copy(buffer)
                 # Direct memory copy for better performance
-                ctypes.memmove(data, buffer, actual_length)
+                ctypes.memmove(data, buffer_view, actual_length)
                 return actual_length
             except Exception as e:
                 print(self._error_messages['read_error'].format(str(e)), file=sys.stderr)

--- a/tests/c2pa.py
+++ b/tests/c2pa.py
@@ -650,11 +650,11 @@ class Stream:
                 Number of bytes read, or -1 on error
             """
             if not self._initialized or self._closed:
-                print(self._error_messages['read'], file=sys.stderr)
+                # print(self._error_messages['read'], file=sys.stderr)
                 return -1
             try:
                 if not data or length <= 0:
-                    print(self._error_messages['memory_error'].format("Invalid read parameters"), file=sys.stderr)
+                    # print(self._error_messages['memory_error'].format("Invalid read parameters"), file=sys.stderr)
                     return -1
                     
                 buffer = self._file.read(length)
@@ -669,7 +669,7 @@ class Stream:
                 ctypes.memmove(data, buffer_view, actual_length)
                 return actual_length
             except Exception as e:
-                print(self._error_messages['read_error'].format(str(e)), file=sys.stderr)
+                # print(self._error_messages['read_error'].format(str(e)), file=sys.stderr)
                 return -1
         
         def seek_callback(ctx, offset, whence):
@@ -690,13 +690,13 @@ class Stream:
                 New position in the stream, or -1 on error
             """
             if not self._initialized or self._closed:
-                print(self._error_messages['seek'], file=sys.stderr)
+                # print(self._error_messages['seek'], file=sys.stderr)
                 return -1
             try:
                 self._file.seek(offset, whence)
                 return self._file.tell()
             except Exception as e:
-                print(self._error_messages['seek_error'].format(str(e)), file=sys.stderr)
+                # print(self._error_messages['seek_error'].format(str(e)), file=sys.stderr)
                 return -1
         
         def write_callback(ctx, data, length):
@@ -718,11 +718,11 @@ class Stream:
                 Number of bytes written, or -1 on error
             """
             if not self._initialized or self._closed:
-                print(self._error_messages['write'], file=sys.stderr)
+                # print(self._error_messages['write'], file=sys.stderr)
                 return -1
             try:
                 if not data or length <= 0:
-                    print(self._error_messages['memory_error'].format("Invalid write parameters"), file=sys.stderr)
+                    # print(self._error_messages['memory_error'].format("Invalid write parameters"), file=sys.stderr)
                     return -1
                     
                 # Create a temporary buffer to safely handle the data
@@ -737,7 +737,7 @@ class Stream:
                     # Ensure temporary buffer is cleared
                     ctypes.memset(temp_buffer, 0, length)
             except Exception as e:
-                print(self._error_messages['write_error'].format(str(e)), file=sys.stderr)
+                # print(self._error_messages['write_error'].format(str(e)), file=sys.stderr)
                 return -1
         
         def flush_callback(ctx):
@@ -755,13 +755,13 @@ class Stream:
                 0 on success, -1 on error
             """
             if not self._initialized or self._closed:
-                print(self._error_messages['flush'], file=sys.stderr)
+                # print(self._error_messages['flush'], file=sys.stderr)
                 return -1
             try:
                 self._file.flush()
                 return 0
             except Exception as e:
-                print(self._error_messages['flush_error'].format(str(e)), file=sys.stderr)
+                # print(self._error_messages['flush_error'].format(str(e)), file=sys.stderr)
                 return -1
         
         # Create callbacks that will be kept alive by being instance attributes

--- a/tests/c2pa.py
+++ b/tests/c2pa.py
@@ -555,8 +555,10 @@ class Stream:
                 return -1
             try:
                 buffer = self._file.read(length)
-                for i, b in enumerate(buffer):
-                    data[i] = b
+                if not buffer:  # EOF
+                    return 0
+                # Direct memory copy for better performance
+                ctypes.memmove(data, buffer, len(buffer))
                 return len(buffer)
             except Exception as e:
                 print(f"Error reading from stream: {str(e)}", file=sys.stderr)
@@ -578,7 +580,8 @@ class Stream:
                 print("Error: Attempted to write to uninitialized or closed stream", file=sys.stderr)
                 return -1
             try:
-                buffer = bytes(data[:length])
+                # Direct memory copy for better performance
+                buffer = (ctypes.c_ubyte * length).from_address(ctypes.addressof(data.contents))
                 self._file.write(buffer)
                 return length
             except Exception as e:

--- a/tests/c2pa.py
+++ b/tests/c2pa.py
@@ -85,11 +85,8 @@ def _validate_library_exports(lib):
     
     if missing_functions:
         raise ImportError(
-            f"Library is missing required functions: {', '.join(missing_functions)}\n"
-            "This could indicate:\n"
-            "1. An incomplete or corrupted library installation\n"
-            "2. A version mismatch between the library and this Python wrapper\n"
-            "3. A potentially malicious library that's missing critical functions"
+            f"Library is missing required functions symbols: {', '.join(missing_functions)}\n"
+            "This could indicate an incomplete or corrupted library installation or a version mismatch between the library and this Python wrapper"
         )
 
 def _try_load_library(path):

--- a/tests/c2pa.py
+++ b/tests/c2pa.py
@@ -370,6 +370,19 @@ class C2paError(Exception):
         """Exception raised for verification errors."""
         pass
 
+class _StringContainer:
+    """Container class to hold encoded strings and prevent them from being garbage collected.
+    
+    This class is used to store encoded strings that need to remain in memory
+    while being used by C functions. The strings are stored as instance attributes
+    to prevent them from being garbage collected.
+    
+    This is an internal implementation detail and should not be used outside this module.
+    """
+    def __init__(self):
+        """Initialize an empty string container."""
+        pass
+
 def _handle_string_result(result: ctypes.c_void_p, check_error: bool = True) -> Optional[str]:
     """Helper function to handle string results from C2PA functions."""
     if not result:  # NULL pointer
@@ -463,10 +476,7 @@ def read_file(path: Union[str, Path], data_dir: Optional[Union[str, Path]] = Non
     Raises:
         C2paError: If there was an error reading the file
     """
-    # Create a container to hold our strings
-    class StringContainer:
-        pass
-    container = StringContainer()
+    container = _StringContainer()
     
     container._path_str = str(path).encode('utf-8')
     container._data_dir_str = str(data_dir).encode('utf-8') if data_dir else None
@@ -487,10 +497,7 @@ def read_ingredient_file(path: Union[str, Path], data_dir: Optional[Union[str, P
     Raises:
         C2paError: If there was an error reading the file
     """
-    # Create a container to hold our strings
-    class StringContainer:
-        pass
-    container = StringContainer()
+    container = _StringContainer()
     
     container._path_str = str(path).encode('utf-8')
     container._data_dir_str = str(data_dir).encode('utf-8') if data_dir else None

--- a/tests/c2pa.py
+++ b/tests/c2pa.py
@@ -1448,7 +1448,7 @@ class Builder:
             raise C2paError.Encoding(self._error_messages['encoding_error'].format(str(e)))
             
         source_stream = Stream(source)
-        result = _lib.c2pa_builder_add_ingredient(self._builder, ingredient_str, format_str, source_stream._stream)
+        result = _lib.c2pa_builder_add_ingredient_from_stream(self._builder, ingredient_str, format_str, source_stream._stream)
         
         if result != 0:
             _handle_string_result(_lib.c2pa_error())

--- a/tests/c2pa.py
+++ b/tests/c2pa.py
@@ -1699,9 +1699,13 @@ def ed25519_sign(data: bytes, private_key: str) -> bytes:
         
     Raises:
         C2paError: If there was an error signing the data
+        C2paError.Encoding: If the private key contains invalid UTF-8 characters
     """
     data_array = (ctypes.c_ubyte * len(data))(*data)
-    key_str = private_key.encode('utf-8')
+    try:
+        key_str = private_key.encode('utf-8')
+    except UnicodeError as e:
+        raise C2paError.Encoding(f"Invalid UTF-8 characters in private key: {str(e)}")
     
     signature_ptr = _lib.c2pa_ed25519_sign(data_array, len(data), key_str)
     

--- a/tests/c2pa.py
+++ b/tests/c2pa.py
@@ -761,7 +761,15 @@ class Reader:
         
         if stream is None:
             # Create a stream from the file path
-            import mimetypes
+
+            # Check if mimetypes is already imported to avoid duplicate imports
+            # This is important because mimetypes initialization can be expensive
+            # and we want to reuse the existing module if it's already loaded
+            if 'mimetypes' not in sys.modules:
+                import mimetypes
+            else:
+                mimetypes = sys.modules['mimetypes']
+                
             path = str(format_or_path)
             mime_type = mimetypes.guess_type(path)[0] or 'application/octet-stream'
             

--- a/tests/c2pa.py
+++ b/tests/c2pa.py
@@ -19,7 +19,6 @@ _REQUIRED_FUNCTIONS = [
     'c2pa_version',
     'c2pa_error',
     'c2pa_string_free',
-    'c2pa_release_string',
     'c2pa_load_settings',
     'c2pa_read_file',
     'c2pa_read_ingredient_file',
@@ -250,7 +249,6 @@ _setup_function(_lib.c2pa_release_stream, [ctypes.POINTER(C2paStream)], None)
 _setup_function(_lib.c2pa_version, [], ctypes.c_void_p)
 _setup_function(_lib.c2pa_error, [], ctypes.c_void_p)
 _setup_function(_lib.c2pa_string_free, [ctypes.c_void_p], None)
-_setup_function(_lib.c2pa_release_string, [ctypes.c_void_p], None)
 _setup_function(_lib.c2pa_load_settings, [ctypes.c_char_p, ctypes.c_char_p], ctypes.c_int)
 _setup_function(_lib.c2pa_read_file, [ctypes.c_char_p, ctypes.c_char_p], ctypes.c_void_p)
 _setup_function(_lib.c2pa_read_ingredient_file, [ctypes.c_char_p, ctypes.c_char_p], ctypes.c_void_p)

--- a/tests/test_c2pa.py
+++ b/tests/test_c2pa.py
@@ -1,6 +1,7 @@
 import os
 import unittest
 import tempfile
+import json
 from pathlib import Path
 from c2pa import (
     C2paError,
@@ -76,7 +77,6 @@ class TestC2PA(unittest.TestCase):
         self.assertGreater(len(manifest), 0)
         
         # Verify it's valid JSON
-        import json
         manifest_data = json.loads(manifest)
         self.assertIsInstance(manifest_data, dict)
         # Verify it has expected C2PA structure
@@ -90,7 +90,6 @@ class TestC2PA(unittest.TestCase):
         self.assertIsInstance(ingredient, str)
         
         # Verify it's valid JSON
-        import json
         ingredient_data = json.loads(ingredient)
         self.assertIsInstance(ingredient_data, dict)
         # Verify it has expected ingredient structure
@@ -128,7 +127,6 @@ class TestC2PA(unittest.TestCase):
         self.assertGreater(len(manifest), 0)
         
         # Verify it's valid JSON
-        import json
         manifest_data = json.loads(manifest)
         self.assertIsInstance(manifest_data, dict)
         self.assertIn("claim_generator", manifest_data)

--- a/tests/test_c2pa.py
+++ b/tests/test_c2pa.py
@@ -1,5 +1,5 @@
 import os
-import pytest
+import unittest
 import tempfile
 from pathlib import Path
 from c2pa import (
@@ -22,241 +22,233 @@ from c2pa import (
 # Test data directory
 TEST_DATA_DIR = Path(__file__).parent / "fixtures"
 
-# Test files
-UNSIGNED_FILE = TEST_DATA_DIR / "A.jpg"
-SIGNED_FILE = TEST_DATA_DIR / "C.jpg"
-CERT_FILE = TEST_DATA_DIR / "test.crt"
-KEY_FILE = TEST_DATA_DIR / "test.key"
+class TestC2PA(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        """Set up test data that will be used by all test methods."""
+        cls.unsigned_file = TEST_DATA_DIR / "A.jpg"
+        cls.signed_file = TEST_DATA_DIR / "C.jpg"
+        cls.cert_file = TEST_DATA_DIR / "test.crt"
+        cls.key_file = TEST_DATA_DIR / "test.key"
 
-@pytest.fixture
-def unsigned_file():
-    """Fixture providing path to unsigned test file."""
-    assert UNSIGNED_FILE.exists(), f"Test file {UNSIGNED_FILE} not found"
-    return UNSIGNED_FILE
+        # Verify test files exist
+        assert cls.unsigned_file.exists(), f"Test file {cls.unsigned_file} not found"
+        assert cls.signed_file.exists(), f"Test file {cls.signed_file} not found"
+        assert cls.cert_file.exists(), f"Certificate file {cls.cert_file} not found"
+        assert cls.key_file.exists(), f"Key file {cls.key_file} not found"
 
-@pytest.fixture
-def signed_file():
-    """Fixture providing path to signed test file."""
-    assert SIGNED_FILE.exists(), f"Test file {SIGNED_FILE} not found"
-    return SIGNED_FILE
+        # Load certificate and key data
+        with open(cls.cert_file, 'rb') as f:
+            cls.cert_data = f.read()
+        with open(cls.key_file, 'rb') as f:
+            cls.key_data = f.read()
 
-@pytest.fixture
-def cert_data():
-    """Fixture providing certificate data."""
-    assert CERT_FILE.exists(), f"Certificate file {CERT_FILE} not found"
-    with open(CERT_FILE, 'rb') as f:
-        return f.read()
+        # Create signer info
+        cls.signer_info = C2paSignerInfo(
+            alg=b"ES256",
+            sign_cert=cls.cert_data,
+            private_key=cls.key_data,
+            ta_url=None  # b"http://test.tsa"
+        )
 
-@pytest.fixture
-def key_data():
-    """Fixture providing private key data."""
-    assert KEY_FILE.exists(), f"Key file {KEY_FILE} not found"
-    with open(KEY_FILE, 'rb') as f:
-        return f.read()
+    def test_version(self):
+        """Test that version() returns a non-empty string."""
+        v = version()
+        self.assertIsInstance(v, str)
+        self.assertGreater(len(v), 0)
 
-@pytest.fixture
-def signer_info(cert_data, key_data):
-    """Fixture providing C2paSignerInfo with valid certificate and key."""
-    return C2paSignerInfo(
-        alg=b"ES256",
-        sign_cert=cert_data,
-        private_key=key_data,
-        ta_url=None  #b"http://test.tsa"
-    )
+    def test_load_settings(self):
+        """Test loading settings."""
+        settings = '{"test": "value"}'
+        load_settings(settings)
+        # No exception means success
 
-def test_version():
-    """Test that version() returns a non-empty string."""
-    v = version()
-    assert isinstance(v, str)
-    assert len(v) > 0
+    def test_read_unsigned_file(self):
+        """Test reading an unsigned JPEG file."""
+        with self.assertRaises(C2paError) as context:
+            read_file(self.unsigned_file)
+        self.assertIn("ManifestNotFound", str(context.exception))
 
-def test_load_settings():
-    """Test loading settings."""
-    settings = '{"test": "value"}'
-    load_settings(settings)
-    # No exception means success
+    def test_read_signed_file(self):
+        """Test reading a signed JPEG file with C2PA manifest."""
+        manifest = read_file(self.signed_file)
+        self.assertIsInstance(manifest, str)
+        self.assertGreater(len(manifest), 0)
+        
+        # Verify it's valid JSON
+        import json
+        manifest_data = json.loads(manifest)
+        self.assertIsInstance(manifest_data, dict)
+        # Verify it has expected C2PA structure
+        self.assertIn("claim_generator_info", manifest_data)
+        self.assertIn("title", manifest_data)
+        self.assertIn("format", manifest_data)
 
-def test_read_unsigned_file(unsigned_file):
-    """Test reading an unsigned JPEG file."""
-    with pytest.raises(C2paError) as exc_info:
-        read_file(unsigned_file)
-    assert "ManifestNotFound" in str(exc_info.value)
+    def test_read_ingredient_file(self):
+        """Test reading a JPEG file as an ingredient."""
+        ingredient = read_ingredient_file(self.unsigned_file)
+        self.assertIsInstance(ingredient, str)
+        
+        # Verify it's valid JSON
+        import json
+        ingredient_data = json.loads(ingredient)
+        self.assertIsInstance(ingredient_data, dict)
+        # Verify it has expected ingredient structure
+        self.assertIn("format", ingredient_data)
+        self.assertIn("title", ingredient_data)
 
-def test_read_signed_file(signed_file):
-    """Test reading a signed JPEG file with C2PA manifest."""
-    manifest = read_file(signed_file)
-    assert isinstance(manifest, str)
-    assert len(manifest) > 0
-    # Verify it's valid JSON
-    import json
-    manifest_data = json.loads(manifest)
-    assert isinstance(manifest_data, dict)
-    # Verify it has expected C2PA structure
-    assert "claim_generator_info" in manifest_data
-    assert "title" in manifest_data
-    assert "format" in manifest_data
+    def test_stream(self):
+        """Test Stream class with a real file."""
+        with open(self.unsigned_file, 'rb') as f:
+            stream = Stream(f)
+            self.assertIsNotNone(stream._stream)
+            stream.close()
 
-def test_read_ingredient_file(unsigned_file):
-    """Test reading a JPEG file as an ingredient."""
-    ingredient = read_ingredient_file(unsigned_file)
-    assert isinstance(ingredient, str)
-    # Verify it's valid JSON
-    import json
-    ingredient_data = json.loads(ingredient)
-    assert isinstance(ingredient_data, dict)
-    # Verify it has expected ingredient structure
-    assert "format" in ingredient_data
-    assert "title" in ingredient_data
-
-def test_stream(unsigned_file):
-    """Test Stream class with a real file."""
-    with open(unsigned_file, 'rb') as f:
-        stream = Stream(f)
-        assert stream._stream is not None
-        stream.close()
-
-def test_reader_unsigned(unsigned_file):
-    """Test Reader class with an unsigned file."""
-    reader = Reader(unsigned_file)
-    assert reader._reader is not None
-    
-    try:
-        manifest = reader.json()
-        assert manifest is None  # Unsigned file should have no manifest
-    except C2paError as e:
-        # This is expected if the file isn't a valid C2PA file
-        assert "not a valid C2PA file" in str(e)
-    
-    reader.close()
-
-def test_reader_signed(signed_file):
-    """Test Reader class with a signed file."""
-    reader = Reader(signed_file)
-    assert reader._reader is not None
-    
-    manifest = reader.json()
-    assert isinstance(manifest, str)
-    assert len(manifest) > 0
-    
-    # Verify it's valid JSON
-    import json
-    manifest_data = json.loads(manifest)
-    assert isinstance(manifest_data, dict)
-    assert "claim_generator" in manifest_data
-    
-    reader.close()
-
-def test_signer(signer_info):
-    """Test Signer class creation and operations."""
-    # Test creating signer from info
-    signer = Signer.from_info(signer_info)
-    assert signer._signer is not None
-    
-    # Test reserve_size
-    try:
-        size = signer.reserve_size()
-        assert isinstance(size, int)
-        assert size >= 0
-    except C2paError as e:
-        # This is expected if the signer info is invalid
-        assert "invalid signer info" in str(e)
-    
-    signer.close()
-    
-    # Test creating signer from callback
-    def test_callback(data: bytes) -> bytes:
-        return b"test_signature"
-    
-    signer = Signer.from_callback(
-        callback=test_callback,
-        alg=C2paSigningAlg.ES256,
-        certs=cert_data.decode('utf-8'),
-        tsa_url="http://test.tsa"
-    )
-    assert signer._signer is not None
-    signer.close()
-
-def test_builder(unsigned_file):
-    """Test Builder class operations with a real file."""
-    # Test creating builder from JSON
-    manifest_json = '{"test": "value"}'
-    builder = Builder.from_json(manifest_json)
-    assert builder._builder is not None
-    
-    # Test builder operations
-    builder.set_no_embed()
-    builder.set_remote_url("http://test.url")
-    
-    # Test adding resource
-    with open(unsigned_file, 'rb') as f:
-        builder.add_resource("test_uri", f)
-    
-    # Test adding ingredient
-    ingredient_json = '{"test": "ingredient"}'
-    with open(unsigned_file, 'rb') as f:
-        builder.add_ingredient(ingredient_json, "image/jpeg", f)
-    
-    builder.close()
-
-def test_ed25519_sign():
-    """Test Ed25519 signing."""
-    data = b"test data"
-    private_key = "test_private_key"
-    
-    try:
-        signature = ed25519_sign(data, private_key)
-        assert isinstance(signature, bytes)
-        assert len(signature) == 64  # Ed25519 signatures are always 64 bytes
-    except C2paError as e:
-        # This is expected if the private key is invalid
-        assert "invalid private key" in str(e)
-
-def test_format_embeddable():
-    """Test formatting embeddable manifest."""
-    format_str = "image/jpeg"
-    manifest_bytes = b"test manifest"
-    
-    try:
-        size, result = format_embeddable(format_str, manifest_bytes)
-        assert isinstance(size, int)
-        assert size >= 0
-        assert isinstance(result, bytes)
-        assert len(result) == size
-    except C2paError as e:
-        # This is expected if the format or manifest is invalid
-        assert "invalid format" in str(e) or "invalid manifest" in str(e)
-
-def test_context_managers(unsigned_file, signed_file, signer_info):
-    """Test context manager functionality with real files."""
-    # Test Reader context manager with unsigned file
-    with Reader(unsigned_file) as reader:
-        assert reader._reader is not None
+    def test_reader_unsigned(self):
+        """Test Reader class with an unsigned file."""
+        reader = Reader(self.unsigned_file)
+        self.assertIsNotNone(reader._reader)
+        
         try:
             manifest = reader.json()
-            assert manifest is None  # Unsigned file should have no manifest
-        except C2paError:
-            pass
-    
-    # Test Reader context manager with signed file
-    with Reader(signed_file) as reader:
-        assert reader._reader is not None
+            self.assertIsNone(manifest)  # Unsigned file should have no manifest
+        except C2paError as e:
+            # This is expected if the file isn't a valid C2PA file
+            self.assertIn("not a valid C2PA file", str(e))
+        
+        reader.close()
+
+    def test_reader_signed(self):
+        """Test Reader class with a signed file."""
+        reader = Reader(self.signed_file)
+        self.assertIsNotNone(reader._reader)
+        
         manifest = reader.json()
-        assert isinstance(manifest, str)
-        assert len(manifest) > 0
-    
-    # Test Signer context manager
-    with Signer.from_info(signer_info) as signer:
-        assert signer._signer is not None
+        self.assertIsInstance(manifest, str)
+        self.assertGreater(len(manifest), 0)
+        
+        # Verify it's valid JSON
+        import json
+        manifest_data = json.loads(manifest)
+        self.assertIsInstance(manifest_data, dict)
+        self.assertIn("claim_generator", manifest_data)
+        
+        reader.close()
+
+    def test_signer(self):
+        """Test Signer class creation and operations."""
+        # Test creating signer from info
+        signer = Signer.from_info(self.signer_info)
+        self.assertIsNotNone(signer._signer)
+        
+        # Test reserve_size
         try:
             size = signer.reserve_size()
-            assert isinstance(size, int)
-            assert size >= 0
-        except C2paError:
-            pass
-    
-    # Test Builder context manager
-    manifest_json = '{"test": "value"}'
-    with Builder.from_json(manifest_json) as builder:
-        assert builder._builder is not None
+            self.assertIsInstance(size, int)
+            self.assertGreaterEqual(size, 0)
+        except C2paError as e:
+            # This is expected if the signer info is invalid
+            self.assertIn("invalid signer info", str(e))
+        
+        signer.close()
+        
+        # Test creating signer from callback
+        def test_callback(data: bytes) -> bytes:
+            return b"test_signature"
+        
+        signer = Signer.from_callback(
+            callback=test_callback,
+            alg=C2paSigningAlg.ES256,
+            certs=self.cert_data.decode('utf-8'),
+            tsa_url="http://test.tsa"
+        )
+        self.assertIsNotNone(signer._signer)
+        signer.close()
+
+    def test_builder(self):
+        """Test Builder class operations with a real file."""
+        # Test creating builder from JSON
+        manifest_json = '{"test": "value"}'
+        builder = Builder.from_json(manifest_json)
+        self.assertIsNotNone(builder._builder)
+        
+        # Test builder operations
         builder.set_no_embed()
         builder.set_remote_url("http://test.url")
+        
+        # Test adding resource
+        with open(self.unsigned_file, 'rb') as f:
+            builder.add_resource("test_uri", f)
+        
+        # Test adding ingredient
+        ingredient_json = '{"test": "ingredient"}'
+        with open(self.unsigned_file, 'rb') as f:
+            builder.add_ingredient(ingredient_json, "image/jpeg", f)
+        
+        builder.close()
+
+    def test_ed25519_sign(self):
+        """Test Ed25519 signing."""
+        data = b"test data"
+        private_key = "test_private_key"
+        
+        try:
+            signature = ed25519_sign(data, private_key)
+            self.assertIsInstance(signature, bytes)
+            self.assertEqual(len(signature), 64)  # Ed25519 signatures are always 64 bytes
+        except C2paError as e:
+            # This is expected if the private key is invalid
+            self.assertIn("invalid private key", str(e))
+
+    def test_format_embeddable(self):
+        """Test formatting embeddable manifest."""
+        format_str = "image/jpeg"
+        manifest_bytes = b"test manifest"
+        
+        try:
+            size, result = format_embeddable(format_str, manifest_bytes)
+            self.assertIsInstance(size, int)
+            self.assertGreaterEqual(size, 0)
+            self.assertIsInstance(result, bytes)
+            self.assertEqual(len(result), size)
+        except C2paError as e:
+            # This is expected if the format or manifest is invalid
+            self.assertTrue("invalid format" in str(e) or "invalid manifest" in str(e))
+
+    def test_context_managers(self):
+        """Test context manager functionality with real files."""
+        # Test Reader context manager with unsigned file
+        with Reader(self.unsigned_file) as reader:
+            self.assertIsNotNone(reader._reader)
+            try:
+                manifest = reader.json()
+                self.assertIsNone(manifest)  # Unsigned file should have no manifest
+            except C2paError:
+                pass
+        
+        # Test Reader context manager with signed file
+        with Reader(self.signed_file) as reader:
+            self.assertIsNotNone(reader._reader)
+            manifest = reader.json()
+            self.assertIsInstance(manifest, str)
+            self.assertGreater(len(manifest), 0)
+        
+        # Test Signer context manager
+        with Signer.from_info(self.signer_info) as signer:
+            self.assertIsNotNone(signer._signer)
+            try:
+                size = signer.reserve_size()
+                self.assertIsInstance(size, int)
+                self.assertGreaterEqual(size, 0)
+            except C2paError:
+                pass
+        
+        # Test Builder context manager
+        manifest_json = '{"test": "value"}'
+        with Builder.from_json(manifest_json) as builder:
+            self.assertIsNotNone(builder._builder)
+            builder.set_no_embed()
+            builder.set_remote_url("http://test.url")
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_unit_tests.py
+++ b/tests/test_unit_tests.py
@@ -25,7 +25,7 @@ testPath = os.path.join(PROJECT_PATH, "tests", "fixtures", "C.jpg")
 
 class TestC2paSdk(unittest.TestCase):
     def test_version(self):
-        print(sdk_version())
+        # print(sdk_version())
         self.assertIn("0.8.0", sdk_version())
 
 

--- a/tests/test_unit_tests.py
+++ b/tests/test_unit_tests.py
@@ -32,32 +32,34 @@ class TestC2paSdk(unittest.TestCase):
 class TestReader(unittest.TestCase):
     def test_stream_read(self):
         with open(testPath, "rb") as file:
-            reader = Reader("image/jpeg",file)
-            json = reader.json()
-            self.assertIn("C.jpg", json)
+            with Reader("image/jpeg", file) as reader:
+                json = reader.json()
+                self.assertIn("C.jpg", json)
 
     def test_stream_read_and_parse(self):
         with open(testPath, "rb") as file:
-            reader = Reader("image/jpeg", file)
-            manifest_store = json.loads(reader.json())
-            title = manifest_store["manifests"][manifest_store["active_manifest"]]["title"]
-            self.assertEqual(title, "C.jpg")
+            with Reader("image/jpeg", file) as reader:
+                manifest_store = json.loads(reader.json())
+                title = manifest_store["manifests"][manifest_store["active_manifest"]]["title"]
+                self.assertEqual(title, "C.jpg")
 
     def test_json_decode_err(self):
         with self.assertRaises(Error.Io):
-            manifest_store = Reader("image/jpeg","foo")
+            with Reader("image/jpeg", "foo") as reader:
+                manifest_store = reader.json()
 
     def test_reader_bad_format(self):
         with self.assertRaises(Error.NotSupported):
             with open(testPath, "rb") as file:
-                reader = Reader("badFormat", file)
+                with Reader("badFormat", file) as reader:
+                    pass
 
     def test_settings_trust(self):
         #load_settings_file("tests/fixtures/settings.toml")
         with open(testPath, "rb") as file:
-            reader = Reader("image/jpeg",file)
-            json = reader.json()
-            self.assertIn("C.jpg", json)
+            with Reader("image/jpeg", file) as reader:
+                json = reader.json()
+                self.assertIn("C.jpg", json)
 
 class TestBuilder(unittest.TestCase):
     # Define a manifest as a dictionary
@@ -108,42 +110,42 @@ class TestBuilder(unittest.TestCase):
     signer = Signer.from_info(signer_info)
     #signer = create_signer(sign, SigningAlg.PS256, certs, "http://timestamp.digicert.com")
 
+    def _read_manifest(self, reader):
+        json_data = reader.json()
+        self.assertIn("Python Test", json_data)
+        self.assertNotIn("validation_status", json_data)
+
     def test_streams_sign(self):
-        with open(testPath, "rb") as file:
-            builder = Builder(TestBuilder.manifestDefinition)
-            output = io.BytesIO(bytearray())
+        with open(testPath, "rb") as file, \
+             io.BytesIO(bytearray()) as output, \
+             Builder(TestBuilder.manifestDefinition) as builder:
             builder.sign(TestBuilder.signer, "image/jpeg", file, output)
             output.seek(0)
-            reader = Reader("image/jpeg", output)
-            json_data = reader.json()
-            self.assertIn("Python Test", json_data)
-            self.assertNotIn("validation_status", json_data)
+            with Reader("image/jpeg", output) as reader:
+                self._read_manifest(reader)
 
     def test_archive_sign(self):
-        with open(testPath, "rb") as file:
-            builder = Builder(TestBuilder.manifestDefinition)
-            archive = io.BytesIO(bytearray())
-            builder.to_archive(archive)
-            builder = Builder.from_archive(archive)
-            output = io.BytesIO(bytearray())
-            builder.sign(TestBuilder.signer, "image/jpeg", file, output)
-            output.seek(0)
-            reader = Reader("image/jpeg", output)
-            json_data = reader.json()
-            self.assertIn("Python Test", json_data)
-            self.assertNotIn("validation_status", json_data)
+        with open(testPath, "rb") as file, \
+             io.BytesIO(bytearray()) as archive:
+            with Builder(TestBuilder.manifestDefinition) as builder:
+                builder.to_archive(archive)
+                archive.seek(0)
+                with Builder.from_archive(archive) as builder2, \
+                     io.BytesIO(bytearray()) as output:
+                    builder2.sign(TestBuilder.signer, "image/jpeg", file, output)
+                    output.seek(0)
+                    with Reader("image/jpeg", output) as reader:
+                        self._read_manifest(reader)
 
     def test_remote_sign(self):
-        with open(testPath, "rb") as file:
-            builder = Builder(TestBuilder.manifestDefinition)
+        with open(testPath, "rb") as file, \
+             io.BytesIO(bytearray()) as output, \
+             Builder(TestBuilder.manifestDefinition) as builder:
             builder.set_no_embed()
-            output = io.BytesIO(bytearray())
             manifest_data = builder.sign(TestBuilder.signer, "image/jpeg", file, output)
             output.seek(0)
-            reader = Reader("image/jpeg", output, manifest_data)
-            json_data = reader.json()
-            self.assertIn("Python Test", json_data)
-            self.assertNotIn("validation_status", json_data)
+            with Reader("image/jpeg", output, manifest_data) as reader:
+                self._read_manifest(reader)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
- Make Stream class usable with context manager (`with` keyword)
- When loading the bound native lib, check needed functions are here to avoid bad surprises
- Streamline error handling
- Rewrite one test file to use unittest instead of pytest (pytest command still can run the tests) to have only one framework used
- Found a bug where `c2pa_builder_add_ingredient` instead of `c2pa_builder_add_ingredient_from_stream` was called, fixed it (The symbol is not in the current lib)
- Make resources cleaning for Reader, Builder, Signer and Stream more robust (esp. avoid double free)
- Probably some other minor things I forgot while working on the above!

Also tested these changes with other implementations we're working on and tests passed there too