### PR TITLE
fix: Update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,7 @@ crate-type = ["lib", "cdylib"]
 
 [dependencies]
 tokio = { version = "1.36", features = ["rt-multi-thread","rt"] }
-cawg-identity = "0.12.0"
-c2pa = { version = "0.49.3", features = [
+c2pa = { version = "0.51.0", features = [
     "file_io",
     "add_thumbnails",
     "fetch_remote_manifests",

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ clippy:
 
 test-rust:
 	cargo test --release
- 
+
 cmake:
 	mkdir -p $(BUILD_DIR)
 	cmake -S./ -B./$(BUILD_DIR) -G "Ninja"
@@ -76,6 +76,6 @@ package:
 	cp README.md target/c2pa-c/README.md
 	cp include/* target/c2pa-c/include
 
-test: test-rust test-cpp 
+test: test-rust test-cpp
 
 all: test examples

--- a/src/c_api.rs
+++ b/src/c_api.rs
@@ -11,7 +11,7 @@
 // specific language governing permissions and limitations under
 // each license.
 
-use cawg_identity::validator::CawgValidator;
+use c2pa::identity::validator::CawgValidator;
 use std::{
     ffi::CString,
     os::raw::{c_char, c_int, c_uchar, c_void},

--- a/src/json_api.rs
+++ b/src/json_api.rs
@@ -10,7 +10,7 @@
 // specific language governing permissions and limitations under
 // each license.
 
-use cawg_identity::validator::CawgValidator;
+use c2pa::identity::validator::CawgValidator;
 use tokio::runtime::Runtime;
 
 use c2pa::{Ingredient, Manifest, Reader};


### PR DESCRIPTION
- Update dependencies, accomodates new deps structure

Extension: https://github.com/contentauth/c2pa-c/pull/72/files adds C Bindings to expand the C API to enar feature-parity with what is being worked on in c2pa-rs.