### PR TITLE
build: adds stricter compile options

### DIFF
--- a/include/c2pa.hpp
+++ b/include/c2pa.hpp
@@ -73,7 +73,7 @@ namespace c2pa
     /// @param format the mime format of the string.
     /// @param data the string to load.
     /// @throws a C2pa::C2paException for errors encountered by the C2PA library.
-    void C2PA_CPP_API load_settings(const string format, const string data);
+    void C2PA_CPP_API load_settings(const string& format, const string& data);
 
     /// Reads a file and returns the manifest json as a C2pa::String.
     /// @param source_path the path to the file to read.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -57,6 +57,9 @@ endif()
 
 # Define the C++ library and add sources
 add_library(c2pa_cpp STATIC c2pa.cpp)
+target_compile_options(c2pa_cpp PRIVATE
+    -Werror -Wmissing-prototypes
+)
 
 # Expose public headers and prebuilt C API headers to clients
 target_include_directories(c2pa_cpp

--- a/src/c2pa.cpp
+++ b/src/c2pa.cpp
@@ -29,6 +29,38 @@ using path = std::filesystem::path;
 using namespace std;
 using namespace c2pa;
 
+namespace {
+
+intptr_t signer_passthrough(const void *context, const unsigned char *data, uintptr_t len, unsigned char *signature, uintptr_t sig_max_len)
+{
+  try
+  {
+    // the context is a pointer to the C++ callback function
+    SignerFunc *callback = (SignerFunc *)context;
+    std::vector<uint8_t> data_vec(data, data + len);
+    std::vector<uint8_t> signature_vec = (callback)(data_vec);
+    if (signature_vec.size() > sig_max_len)
+    {
+      return -1;
+    }
+    std::copy(signature_vec.begin(), signature_vec.end(), signature);
+    return signature_vec.size();
+  }
+  catch (std::exception const &e)
+  {
+    // todo pass exceptions to Rust error handling
+    (void)e;
+    // printf("Error: signer_passthrough - %s\n", e.what());
+    return -1;
+  }
+  catch (...)
+  {
+    // printf("Error: signer_passthrough - unknown C2paException\n");
+    return -1;
+  }
+}
+}
+
 namespace c2pa
 {
     /// C2paException class for C2PA errors.
@@ -544,34 +576,6 @@ namespace c2pa
         return result;
     }
 
-    intptr_t signer_passthrough(const void *context, const unsigned char *data, uintptr_t len, unsigned char *signature, uintptr_t sig_max_len)
-    {
-        try
-        {
-            // the context is a pointer to the C++ callback function
-            SignerFunc *callback = (SignerFunc *)context;
-            std::vector<uint8_t> data_vec(data, data + len);
-            std::vector<uint8_t> signature_vec = (callback)(data_vec);
-            if (signature_vec.size() > sig_max_len)
-            {
-                return -1;
-            }
-            std::copy(signature_vec.begin(), signature_vec.end(), signature);
-            return signature_vec.size();
-        }
-        catch (std::exception const &e)
-        {
-            // todo pass exceptions to Rust error handling
-            (void)e;
-            // printf("Error: signer_passthrough - %s\n", e.what());
-            return -1;
-        }
-        catch (...)
-        {
-            // printf("Error: signer_passthrough - unknown C2paException\n");
-            return -1;
-        }
-    }
 
     Signer::Signer(SignerFunc *callback, C2paSigningAlg alg, const string &sign_cert, const string &tsa_uri)
     {

--- a/tests/test.c
+++ b/tests/test.c
@@ -21,7 +21,7 @@
 int main(void)
 {
     char *version = c2pa_version();
-    assert_contains("version", version, "c2pa-c/0.");
+    assert_contains("version", version, "c_api/0.");
 
     char *result1 = c2pa_read_file("tests/fixtures/C.jpg", NULL);
     assert_str_not_null("c2pa_read_file_no_data_dir", result1);
@@ -77,7 +77,7 @@ int main(void)
     result = c2pa_sign_file("tests/fixtures/foo.jpg", "build/tmp/earth.jpg", manifest, &sign_info, "tests/fixtures");
     assert_null("c2pa_sign_file_not_found", result, "FileNotFound");
 
-    result = c2pa_sign_file("tests/fixtures/es256_certs.pem", "build/tmp/earth.jpg", manifest, &sign_info, "tests/fixtures");
+    result = c2pa_sign_file("tests/fixtures/es256_certs.pem", "build/tmp/earth1.pem", manifest, &sign_info, "tests/fixtures");
     assert_null("c2pa_sign_file_not_supported", result, "NotSupported");
 
     C2paBuilder *builder = c2pa_builder_from_json(manifest);

--- a/tests/version.test.cpp
+++ b/tests/version.test.cpp
@@ -15,5 +15,5 @@
 
 TEST(Version, VersionReturnsInCorrectFormat) {
   auto version = c2pa::version();
-  ASSERT_TRUE(version.find("c2pa-c/0.") != std::string::npos);
+  ASSERT_TRUE(version.find("c_api/0.") != std::string::npos);
 }


### PR DESCRIPTION
The added compile options are used by clients. Without this change, they are unable to build their projects.

Implements: CAI-8548