### PR TITLE
fix: Do we really need the flag -Wmissing-prototypes?

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -58,7 +58,7 @@ endif()
 # Define the C++ library and add sources
 add_library(c2pa_cpp STATIC c2pa.cpp)
 target_compile_options(c2pa_cpp PRIVATE
-    -Werror -Wmissing-prototypes
+    -Werror
 )
 
 # Expose public headers and prebuilt C API headers to clients


### PR DESCRIPTION
`-Wmissing-prototypes` should be removed, as it is only valid for C code, but this repo is C++ only now.

This can cause issues for some build configs otherwise that complain about the flag being set on C++ code, whereas it's a C flag.