### PR TITLE
fix: `load_settings` parameters swapped

### DIFF
--- a/include/c2pa.hpp
+++ b/include/c2pa.hpp
@@ -70,10 +70,10 @@ namespace c2pa
     string C2PA_CPP_API version();
 
     /// Loads C2PA settings from a string in a given format.
-    /// @param format the mime format of the string.
     /// @param data the string to load.
+    /// @param format the mime format of the string.
     /// @throws a C2pa::C2paException for errors encountered by the C2PA library.
-    void C2PA_CPP_API load_settings(const string& format, const string& data);
+    void C2PA_CPP_API load_settings(const string& data, const string& format);
 
     /// Reads a file and returns the manifest json as a C2pa::String.
     /// @param source_path the path to the file to read.

--- a/src/c2pa.cpp
+++ b/src/c2pa.cpp
@@ -112,12 +112,12 @@ namespace c2pa
     }
 
     /// Loads C2PA settings from a string in a given format.
-    /// @param format the mime format of the string.
     /// @param data the string to load.
+    /// @param format the mime format of the string.
     /// @throws a C2pa::C2paException for errors encountered by the C2PA library.
-    void load_settings(const string &format, const string &data)
+    void load_settings(const string &data, const string &format)
     {
-        auto result = c2pa_load_settings(format.c_str(), data.c_str());
+        auto result = c2pa_load_settings(data.c_str(), format.c_str());
         if (result != 0)
         {
             throw c2pa::C2paException();
@@ -538,7 +538,7 @@ namespace c2pa
         if (!file_stream.is_open())
         {
             // Use std::system_error for cross-platform error handling
-            throw C2paException("Failed to open file: " + source_path.string() + " - " + 
+            throw C2paException("Failed to open file: " + source_path.string() + " - " +
                                std::system_error(errno, std::system_category()).what());
         }
         string extension = source_path.extension().string();


### PR DESCRIPTION
Looks like we have the parameters mixed up in the C++ API. This is a quick fix before we transition to the TOML-only API.