### PR TITLE
Add script to generate API reference docs with Doxygen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,9 @@ CMakeOutput.log
 CMakeError.log
 CMakeLists.txt.user
 
+# Doxygen docs
+/docs/_build
+
 .vscode
 # Mac OS X files
 .DS_Store

--- a/Doxyfile
+++ b/Doxyfile
@@ -1,0 +1,39 @@
+PROJECT_NAME           = "c2pa-c"
+PROJECT_BRIEF          = "C API for the C2PA library"
+OUTPUT_DIRECTORY       = docs/_build
+CREATE_SUBDIRS         = YES
+GENERATE_HTML          = YES
+GENERATE_LATEX         = NO
+GENERATE_MAN           = NO
+GENERATE_XML           = YES
+ALWAYS_DETAILED_SEC    = YES
+INLINE_SOURCES         = YES
+STRIP_CODE_COMMENTS    = NO
+
+INPUT                  = include src README.md
+FILE_PATTERNS          = *.h *.hpp *.c
+RECURSIVE              = YES
+EXCLUDE_SYMLINKS       = YES
+
+MARKDOWN_SUPPORT       = YES
+USE_MDFILE_AS_MAINPAGE = README.md
+
+HTML_OUTPUT            = html
+HTML_COLORSTYLE_HUE    = 209
+GENERATE_TREEVIEW      = YES
+HTML_EXTRA_STYLESHEET  = docs/doxygen-extra.css
+
+QUIET                  = NO
+WARN_IF_UNDOCUMENTED   = NO
+EXTRACT_ALL            = YES
+EXTRACT_PRIVATE        = NO
+EXTRACT_STATIC         = YES
+EXTRACT_LOCAL_METHODS  = YES
+
+ENABLE_PREPROCESSING   = YES
+MACRO_EXPANSION        = YES
+EXPAND_ONLY_PREDEF     = NO
+PREDEFINED             = DOXYGEN=1
+
+STRIP_FROM_PATH        = include src
+

--- a/Makefile
+++ b/Makefile
@@ -44,3 +44,7 @@ clean:
 
 .PHONY: all debug release cmake test test-release demo training examples clean
 
+# Build C API docs with Doxygen
+docs:
+	./scripts/generate_api_docs.sh
+

--- a/README.md
+++ b/README.md
@@ -6,12 +6,14 @@ The [c2pa-c repository](https://github.com/contentauth/c2pa-c) implements C++ AP
 
 Although this library works for plain C applications, the documentation assumes you're using C++, since that's most common for modern applications.
 
+<div class="hide-doxygen" >
 <div style={{display: 'none'}}>
 
 For the best experience, read the docs on the [CAI Open Source SDK documentation website](https://opensource.contentauthenticity.org/docs/c2pa-c).  If you want to view the documentation in GitHub, see:
 - [Using the C++ library](docs/usage.md)
 - [Supported formats](https://github.com/contentauth/c2pa-rs/blob/crandmck/reorg-docs/docs/supported-formats.md)
 
+</div>
 </div>
 
 ## Using c2pa_cpp in Your Application
@@ -74,6 +76,30 @@ Build the [unit tests](https://github.com/contentauth/c2pa-c/tree/main/tests) by
 ```
 make unit-test
 ```
+
+## API documentation
+
+Generate API docs using Doxygen.
+
+- Configuration file: `c2pa-c/Doxyfile` 
+- Script: `c2pa-c/scripts/generate_api_docs.sh`
+- Output directory: `docs/_build/html`
+
+Install Doxygen if needed:
+
+```
+macOS: brew install doxygen
+Ubuntu/Debian: sudo apt-get install doxygen
+```
+
+Generate docs:
+```
+make -C docs
+```
+
+Open `build/html/index.html`
+
+
 
 ## License
 

--- a/docs/doxygen-extra.css
+++ b/docs/doxygen-extra.css
@@ -1,0 +1,5 @@
+/* Custom classes for Doxygen HTML */
+.hide-doxygen {
+  display: none;
+}
+

--- a/scripts/generate_api_docs.sh
+++ b/scripts/generate_api_docs.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+if ! command -v doxygen >/dev/null 2>&1; then
+  echo "Error: doxygen is not installed. Install it via: brew install doxygen (macOS) or apt-get install doxygen (Linux)." >&2
+  exit 1
+fi
+
+OUT_DIR="docs/_build/html"
+rm -rf "docs/_build" || true
+
+doxygen Doxyfile | cat
+
+echo "Doxygen HTML docs: $OUT_DIR/index.html"
+


### PR DESCRIPTION
This adds a script to generate API reference docs using Doxygen.

To do this properly, we need to add a GH worfkow similar to this https://github.com/creator-assertions/creator-assertions.github.io/blob/main/.github/workflows/publish.yml, which will build the docs using Sphinx and deploy them to GH Pages for consumption.  We can then link to that from the OS doc site.