### PR TITLE
bug-repro: Show repro for 2 bugs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ cmake_minimum_required(VERSION 3.27)
 project(c2pa-c VERSION 0.10.0)
 
 # Set the version of the c2pa_rs library used here
-set(C2PA_VERSION "0.63.0")
+set(C2PA_VERSION "0.66.0")
 
 set(CMAKE_POLICY_DEFAULT_CMP0135 NEW)
 set(CMAKE_C_STANDARD 17)

--- a/tests/builder.test.cpp
+++ b/tests/builder.test.cpp
@@ -568,9 +568,22 @@ TEST(Builder, NoSignOnInvalidDoubleParentsManifest)
     std::vector<unsigned char> manifest_data;
 
     // v0.66.0 update: Shouldn't this throw due to 2 parents?
-    EXPECT_THROW(builder.sign("image/jpeg", source, dest, signer), c2pa::C2paException);
+    // EXPECT_THROW(builder.sign("image/jpeg", source, dest, signer), c2pa::C2paException);
+
+    manifest_data = builder.sign("image/jpeg", source, dest, signer);
+    source.close();
+
+    // Rewind dest to the start
+    dest.flush();
+    dest.seekp(0, std::ios::beg);
+    auto reader = c2pa::Reader("image/jpeg", dest);
+
+    std::cout << "json: " << reader.json() << std::endl;
+    std::cout.flush();
 
     source.close();
+
+    ASSERT_TRUE(false);
 }
 
 TEST(Builder, SignStreamCloudUrl)

--- a/tests/builder.test.cpp
+++ b/tests/builder.test.cpp
@@ -1083,9 +1083,6 @@ TEST(Builder, AddIngredientToBuilderUsingBasePathWithManifestContainingPlacedAct
     auto reader = c2pa::Reader(output_path);
     ASSERT_NO_THROW(reader.json());
 
-    std::cout << "manifest_data: " << reader.json() << std::endl;
-    std::cout.flush();
-
     // set settings to not generate thumbnails
     c2pa::load_settings("{\"builder\": { \"actions\": {\"auto_placed_action\": {\"enabled\": true}}}}", "json");
 }

--- a/tests/builder.test.cpp
+++ b/tests/builder.test.cpp
@@ -567,9 +567,8 @@ TEST(Builder, NoSignOnInvalidDoubleParentsManifest)
     // are now handled gracefully rather than causing a failure
     std::vector<unsigned char> manifest_data;
 
-    // v0.66.0 update: Shouldn't this throw due to 2 parents?
+    // v0.66.0 update: Shouldn't this throw due to 2 parents? Because that lets you sign invalid manifests now.
     // EXPECT_THROW(builder.sign("image/jpeg", source, dest, signer), c2pa::C2paException);
-
     manifest_data = builder.sign("image/jpeg", source, dest, signer);
     source.close();
 

--- a/tests/builder.test.cpp
+++ b/tests/builder.test.cpp
@@ -1005,7 +1005,7 @@ TEST(Builder, AddIngredientToBuilderUsingBasePath)
 TEST(Builder, AddIngredientToBuilderUsingBasePathWithManifestContainingPlacedAction)
 {
     fs::path current_dir = fs::path(__FILE__).parent_path();
-    fs::path manifest_path = current_dir / "../tests/fixtures/base-path-manifest.json";
+    fs::path manifest_path = current_dir / "../tests/fixtures/base-path-test-manifest-with-placeholder.json";
 
     // Construct the path to the test fixture
     fs::path ingredient_source_path = current_dir / "../tests/fixtures/A.jpg";
@@ -1014,8 +1014,8 @@ TEST(Builder, AddIngredientToBuilderUsingBasePathWithManifestContainingPlacedAct
     // Use target/tmp like other tests
     fs::path temp_dir = current_dir / "../build/ingredient_as_resource_temp_dir";
 
-    // set settings to not generate thumbnails
-    //c2pa::load_settings("{\"builder\": { \"actions\": {\"auto_placed_action\": {\"enabled\": false}}}}", "json");
+    // set settings to not auto-add a placed action
+    // c2pa::load_settings("{\"builder\": { \"actions\": {\"auto_placed_action\": {\"enabled\": false}}}}", "json");
 
     // Remove and recreate the build/ingredient_as_resource_temp_dir folder before using it
     // This is technically a clean-up in-between tests
@@ -1043,14 +1043,49 @@ TEST(Builder, AddIngredientToBuilderUsingBasePathWithManifestContainingPlacedAct
         }
     }
 
-    // Read the placeholder manifest that we'll extend
-    auto manifest = read_text_file(manifest_path);
+    // Initialize the manifest JSON directly
+    std::string manifest = R"({
+        "vendor": "adobe",
+        "claim_generator_info": [
+            {
+                "name": "c2pa-c test",
+                "version": "1.0.0"
+            }
+        ],
+        "assertions": [
+            {
+                "label": "c2pa.actions",
+                "data": {
+                    "actions": [
+                        {
+                            "action": "c2pa.created",
+                            "description": "Created a new file or content",
+                            "parameters": {
+                                "com.vendor.tool": "new"
+                            },
+                            "digitalSourceType": "http://cv.iptc.org/newscodes/digitalsourcetype/digitalCreation"
+                        },
+                        {
+                            "action": "c2pa.placed",
+                            "description": "Added pre-existing content to this file",
+                            "parameters": {
+                                "com.vendor.tool": "place_embedded_smart_object",
+                                "ingredientIds": ["placeholder_ingredient_id"]
+                            }
+                        }
+                    ],
+                    "metadata": {
+                        "dateTime": "2025-09-25T20:59:48.262Z"
+                    }
+                }
+            }
+        ]
+    })";
 
     // Add ingredients array to the manifest JSON, since we manually handle the manifest changes...
     // And we are adding ingredients more manually than through the Builder.add_ingredient call.
 
     // Note: Fragile JSON parsing, but OK for testing purposes.
-    // Parse the JSON and add ingredients array
     std::string modified_manifest = manifest;
     // Find the last closing brace and insert ingredients array before it
     size_t last_brace = modified_manifest.find_last_of('}');
@@ -1058,21 +1093,27 @@ TEST(Builder, AddIngredientToBuilderUsingBasePathWithManifestContainingPlacedAct
         std::string ingredients_array = ",\n  \"ingredients\": [\n    " + result + "\n  ]";
         modified_manifest.insert(last_brace, ingredients_array);
     }
-    // Add instanceId parameter to the c2pa.placed action
+    // Update the ingredientIds parameter in the c2pa.placed action to reference the actual ingredient
     if (!instance_id.empty()) {
-        // Find the c2pa.placed action and add instanceId to its parameters
+        // Find the c2pa.placed action and update its ingredientIds parameter
         size_t placed_action_start = modified_manifest.find("\"action\": \"c2pa.placed\"");
         if (placed_action_start != std::string::npos) {
             // Find the parameters section of this action
             size_t parameters_start = modified_manifest.find("\"parameters\": {", placed_action_start);
             if (parameters_start != std::string::npos) {
-                // Find the end of the parameters object
-                size_t parameters_end = modified_manifest.find("}", parameters_start);
-                if (parameters_end != std::string::npos) {
-                    // Insert instanceId before the closing brace of parameters
-                    std::string instance_id_param = ",\n              \"instanceId\": \"" + instance_id + "\"";
-                    modified_manifest.insert(parameters_end, instance_id_param);
-                    // Successfully added instanceId parameter to c2pa.placed action
+                // Find the ingredientIds parameter and replace its value
+                size_t ingredient_ids_start = modified_manifest.find("\"ingredientIds\":", parameters_start);
+                if (ingredient_ids_start != std::string::npos) {
+                    // Find the array value of the ingredientIds parameter
+                    size_t array_start = modified_manifest.find("[", ingredient_ids_start);
+                    if (array_start != std::string::npos) {
+                        size_t array_end = modified_manifest.find("]", array_start);
+                        if (array_end != std::string::npos) {
+                            // Replace the placeholder with the actual instance_id
+                            std::string ingredient_ids_array = "[\"" + instance_id + "\"]";
+                            modified_manifest.replace(array_start, array_end - array_start + 1, ingredient_ids_array);
+                        }
+                    }
                 }
             }
         }
@@ -1100,11 +1141,11 @@ TEST(Builder, AddIngredientToBuilderUsingBasePathWithManifestContainingPlacedAct
     auto reader = c2pa::Reader(output_path);
     ASSERT_NO_THROW(reader.json());
 
-    std::cout << "manifest_data: " << reader.json() << std::endl;
+    std::cout << "json: " << reader.json() << std::endl;
     std::cout.flush();
 
-    // set settings to not generate thumbnails
-    //c2pa::load_settings("{\"builder\": { \"actions\": {\"auto_placed_action\": {\"enabled\": true}}}}", "json");
+    // set settings to not auto-add a placed action
+    // c2pa::load_settings("{\"builder\": { \"actions\": {\"auto_placed_action\": {\"enabled\": true}}}}", "json");
 
     ASSERT_TRUE(false);
 }

--- a/tests/builder.test.cpp
+++ b/tests/builder.test.cpp
@@ -563,8 +563,13 @@ TEST(Builder, NoSignOnInvalidDoubleParentsManifest)
     std::stringstream memory_buffer(std::ios::in | std::ios::out | std::ios::binary);
     std::iostream &dest = memory_buffer;
 
-    // Expect the sign operation to fail due to invalid manifest (multiple parent ingredients)
+    // The validation logic has changed in the new version - multiple parent ingredients
+    // are now handled gracefully rather than causing a failure
+    std::vector<unsigned char> manifest_data;
+
+    // v0.66.0 update: Shouldn't this throw due to 2 parents?
     EXPECT_THROW(builder.sign("image/jpeg", source, dest, signer), c2pa::C2paException);
+
     source.close();
 }
 
@@ -998,7 +1003,7 @@ TEST(Builder, AddIngredientToBuilderUsingBasePathWithManifestContainingPlacedAct
     fs::path temp_dir = current_dir / "../build/ingredient_as_resource_temp_dir";
 
     // set settings to not generate thumbnails
-    c2pa::load_settings("{\"builder\": { \"actions\": {\"auto_placed_action\": {\"enabled\": false}}}}", "json");
+    //c2pa::load_settings("{\"builder\": { \"actions\": {\"auto_placed_action\": {\"enabled\": false}}}}", "json");
 
     // Remove and recreate the build/ingredient_as_resource_temp_dir folder before using it
     // This is technically a clean-up in-between tests
@@ -1083,10 +1088,14 @@ TEST(Builder, AddIngredientToBuilderUsingBasePathWithManifestContainingPlacedAct
     auto reader = c2pa::Reader(output_path);
     ASSERT_NO_THROW(reader.json());
 
+    std::cout << "manifest_data: " << reader.json() << std::endl;
+    std::cout.flush();
+
     // set settings to not generate thumbnails
-    c2pa::load_settings("{\"builder\": { \"actions\": {\"auto_placed_action\": {\"enabled\": true}}}}", "json");
+    //c2pa::load_settings("{\"builder\": { \"actions\": {\"auto_placed_action\": {\"enabled\": true}}}}", "json");
+
+    ASSERT_TRUE(false);
 }
-//*/
 
 TEST(Builder, AddIngredientWithProvenanceDataToBuilderUsingBasePath)
 {

--- a/tests/fixtures/base-path-manifest.json
+++ b/tests/fixtures/base-path-manifest.json
@@ -15,17 +15,15 @@
             "action": "c2pa.created",
             "description": "Created a new file or content",
             "parameters": {
-              "com.adobe.icon": "https://cai-assertions.adobe.com/icons/new-item-dark.svg",
-              "com.adobe.tool": "new"
+              "com.vendor.tool": "new"
             },
-            "digitalSourceType": "http://c2pa.org/digitalsourcetype/empty"
+            "digitalSourceType": "http://cv.iptc.org/newscodes/digitalsourcetype/digitalCreation"
           },
           {
             "action": "c2pa.placed.v2",
             "description": "Added pre-existing content to this file",
             "parameters": {
-              "com.adobe.icon": "https://cai-assertions.adobe.com/icons/save-to-light-dark.svg",
-              "com.adobe.tool": "place_embedded_smart_object"
+              "com.vendor.tool": "place_embedded_smart_object"
             }
           }
         ],

--- a/tests/fixtures/base-path-manifest.json
+++ b/tests/fixtures/base-path-manifest.json
@@ -2,9 +2,8 @@
   "vendor": "adobe",
   "claim_generator_info": [
     {
-      "name": "Adobe Photoshop",
-      "version": "27.0.0",
-      "com.adobe.build": "20250925.67785.18 fa92201 mac"
+      "name": "c2pa-c test",
+      "version": "1.0.0"
     }
   ],
   "assertions": [

--- a/tests/fixtures/base-path-manifest.json
+++ b/tests/fixtures/base-path-manifest.json
@@ -1,0 +1,39 @@
+{
+  "vendor": "adobe",
+  "claim_generator_info": [
+    {
+      "name": "Adobe Photoshop",
+      "version": "27.0.0",
+      "com.adobe.build": "20250925.67785.18 fa92201 mac"
+    }
+  ],
+  "assertions": [
+    {
+      "label": "c2pa.actions",
+      "data": {
+        "actions": [
+          {
+            "action": "c2pa.created",
+            "description": "Created a new file or content",
+            "parameters": {
+              "com.adobe.icon": "https://cai-assertions.adobe.com/icons/new-item-dark.svg",
+              "com.adobe.tool": "new"
+            },
+            "digitalSourceType": "http://c2pa.org/digitalsourcetype/empty"
+          },
+          {
+            "action": "c2pa.placed.v2",
+            "description": "Added pre-existing content to this file",
+            "parameters": {
+              "com.adobe.icon": "https://cai-assertions.adobe.com/icons/save-to-light-dark.svg",
+              "com.adobe.tool": "place_embedded_smart_object"
+            }
+          }
+        ],
+        "metadata": {
+          "dateTime": "2025-09-25T20:59:48.262Z"
+        }
+      }
+    }
+  ]
+}

--- a/tests/fixtures/base-path-manifest.json
+++ b/tests/fixtures/base-path-manifest.json
@@ -8,7 +8,7 @@
   ],
   "assertions": [
     {
-      "label": "c2pa.actions",
+      "label": "c2pa.actions.v2",
       "data": {
         "actions": [
           {
@@ -20,7 +20,7 @@
             "digitalSourceType": "http://cv.iptc.org/newscodes/digitalsourcetype/digitalCreation"
           },
           {
-            "action": "c2pa.placed.v2",
+            "action": "c2pa.placed",
             "description": "Added pre-existing content to this file",
             "parameters": {
               "com.vendor.tool": "place_embedded_smart_object"

--- a/tests/test.c
+++ b/tests/test.c
@@ -106,11 +106,11 @@ int main(void)
     C2paStream *dest = open_file_stream("build/tmp/earth4.jpg", "w+b");
 
     const unsigned char *manifest_bytes = NULL; // todo: test passing NULL instead of a pointer
-    int result2 = c2pa_builder_sign(builder2, "image/jpeg", source, dest, signer, &manifest_bytes);
-    assert_int("c2pa_builder_sign", result2);
+    int64_t manifest_size = c2pa_builder_sign(builder2, "image/jpeg", source, dest, signer, &manifest_bytes);
+    assert_int("c2pa_builder_sign", manifest_size);
 
     const unsigned char *formatted_bytes = NULL;
-    int64_t result3 = c2pa_format_embeddable("image/jpeg", manifest_bytes, 0, (const unsigned char **)&formatted_bytes);
+    int64_t result3 = c2pa_format_embeddable("image/jpeg", manifest_bytes, manifest_size, (const unsigned char **)&formatted_bytes);
     assert_int("c2pa_format_embeddable", result3);
     c2pa_manifest_bytes_free(manifest_bytes);
     c2pa_manifest_bytes_free(formatted_bytes);


### PR DESCRIPTION
- Repro issue 1: When upgrading to v0.66.0 of c2pa-rs, it has become possible to sign a manifest with 2 ingredients having a "parentOf" relationship. Before the upgrade (v0.63.0), the Builder would throw on attempt to sign such a manifest. This is reproduced in test `NoSignOnInvalidDoubleParentsManifest` (https://github.com/contentauth/c2pa-c/blob/b4b63a2b453751ba16e4c20d84cbe57b643a98fa/tests/builder.test.cpp#L530C15-L530C51). 
- Repro issue 2: If the auto-add of a placed action is not deactivated, with a manually built manifest, the c2pa.placed action may be duplicated: one action will hold all data, the duplicated one will jsut hold the ingredients information. This is reproduced in the test `AddIngredientToBuilderUsingBasePathWithManifestContainingPlacedAction` (https://github.com/contentauth/c2pa-c/blob/b4b63a2b453751ba16e4c20d84cbe57b643a98fa/tests/builder.test.cpp#L1005).

Both tests have an ASSERT(TRUE) at the end to make obvious which tests reproduce issues. The test `AddIngredientToBuilderUsingBasePathWithManifestContainingPlacedAction` for the c2pa.placed issue also logs the signed manifest.