### PR TITLE
fix: initialise default `tsa_uri` in `c2pa::Signer` constructor with an empty string

### DIFF
--- a/include/c2pa.hpp
+++ b/include/c2pa.hpp
@@ -257,7 +257,7 @@ namespace c2pa
 
         Signer(C2paSigner *signer) : signer(signer) {}
 
-        Signer(const string &alg, const string &sign_cert, const string&private_key, const string &tsa_uri = {});
+        Signer(const string &alg, const string &sign_cert, const string &private_key, const optional<string> &tsa_uri = nullopt);
 
         ~Signer();
 

--- a/src/c2pa.cpp
+++ b/src/c2pa.cpp
@@ -606,9 +606,9 @@ namespace c2pa
         signer = c2pa_signer_create((const void *)callback, &signer_passthrough, alg, sign_cert.c_str(), tsa_uri.c_str());
     }
 
-    Signer::Signer(const string &alg, const string &sign_cert, const string &private_key, const string &tsa_uri)
+    Signer::Signer(const string &alg, const string &sign_cert, const string &private_key, const optional<string> &tsa_uri)
     {
-        auto info = C2paSignerInfo { alg.c_str(), sign_cert.c_str(), private_key.c_str(), tsa_uri.c_str()};
+        auto info = C2paSignerInfo { alg.c_str(), sign_cert.c_str(), private_key.c_str(), tsa_uri ? tsa_uri->c_str() : nullptr };
         signer = c2pa_signer_from_info(&info);
     }
 


### PR DESCRIPTION
Constructing a `std::string` from a `nullptr` is undefined behavior and has been removed in C++23.

This fix ensures well-defined behavior and allows the project to build successfully when using the C++23 standard.