### PR TITLE
docs: Edits and clean up, fix examples in Working stores docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ If you want to view the documentation in GitHub, see:
 - [Using the C++ library](docs/usage.md)
 - [Supported formats](https://github.com/contentauth/c2pa-rs/blob/main/docs/supported-formats.md)
 - [Configuring the SDK using `Context` and `Settings`](docs/context-settings.md)
+- [Using Builder intents](docs/intents.md) to ensure spec-compliant manifests
 - Using [working stores and archvies](docs/working-stores.md)
 - Selectively constructing manifests by [filtering actions and ingredients](docs/selective-manifests.md)
 - Using the [embeddable API for low-level control over embedding manifests](docs/embeddable-api.md)

--- a/docs/context-settings.md
+++ b/docs/context-settings.md
@@ -99,7 +99,7 @@ c2pa::Context context(settings);
 There are several ways to create a `Context`:
 - [Use SDK defaults](#use-sdk-defaults)
 - [Create from inline JSON](#create-from-inline-json)
-- [Create from a Settings objec](#create-from-a-settings-object)
+- [Create from a Settings object](#create-from-a-settings-object)
 - [Create using ContextBuilder](#create-using-contextbuilder)
 
 ### Use SDK defaults
@@ -553,7 +553,7 @@ auto validation_result = reader.json();
 
 The [`builder` settings](https://opensource.contentauthenticity.org/docs/manifest/json-ref/settings-schema/#buildersettings) control how the SDK creates and embeds C2PA manifests:
 
-- [Builder intent](#builder-intent) to to specify the purpose of the claim (for example create or edit).
+- [Builder intent](#builder-intent) to specify the purpose of the claim (for example create or edit).
 - [Claim generator information](#claim-generator-information) - Identifies your application in the manifest.
 - [Thumbnail settings](#thumbnail-settings)
 - Action tracking settings - See [ActionsSettings in the SDK object reference](https://opensource.contentauthenticity.org/docs/manifest/json-ref/settings-schema#actionssettings).

--- a/docs/faqs.md
+++ b/docs/faqs.md
@@ -1,23 +1,6 @@
 # Frequently-asked questions (FAQs)
 
-## When do I use `Reader` vs. `Builder`
-
-## Quick reference decision tree
-
-```mermaid
-flowchart TD
-    Q1{Need to read an existing manifest?}
-    Q1 -->|No| USE_B["Use Builder alone (new manifest from scratch)"]
-    Q1 -->|Yes| Q2{Need to create a new/modified manifest?}
-    Q2 -->|No| USE_R["Use Reader alone (inspect/extract only)"]
-    Q2 -->|Yes| USE_BR[Use both Reader + Builder]
-    USE_BR --> Q3{What to keep from the existing manifest?}
-    Q3 -->|Everything| P1["add_ingredient() with original asset or archive path"]
-    Q3 -->|Some parts| P2["1. Read: reader.json() + get_resource() 2. Filter: pick ingredients & actions to keep 3. Build: new Builder with filtered JSON 4. Transfer: .add_resource for kept binaries 5. Sign: builder.sign()"]
-    Q3 -->|Nothing| P3["New Builder alone (fresh manifest, no prior provenance)"]
-```
-
-### When to use `Reader`
+## When do I use `Reader` versus `Builder`?
 
 **Use a `Reader` when the goal is only to inspect or extract data without creating a new manifest.**
 
@@ -34,8 +17,6 @@ reader.get_resource(thumb_id, stream);   // extract a thumbnail
 ```
 
 The `Reader` is read-only. It never modifies the source asset.
-
-### When to use a `Builder`
 
 **Use a `Builder` when creating a manifest from scratch on an asset that has no existing C2PA data, or when intentionally starting with a clean slate.**
 
@@ -76,6 +57,21 @@ c2pa::Builder builder(context, kept.dump());
 builder.sign(source, output, signer);
 ```
 
+### Quick reference decision tree
+
+```mermaid
+flowchart TD
+    Q1{Need to read an existing manifest?}
+    Q1 -->|No| USE_B["Use Builder alone (new manifest from scratch)"]
+    Q1 -->|Yes| Q2{Need to create a new/modified manifest?}
+    Q2 -->|No| USE_R["Use Reader alone (inspect/extract only)"]
+    Q2 -->|Yes| USE_BR[Use both Reader + Builder]
+    USE_BR --> Q3{What to keep from the existing manifest?}
+    Q3 -->|Everything| P1["add_ingredient() with original asset or archive path"]
+    Q3 -->|Some parts| P2["1. Read: reader.json() + get_resource() 2. Filter: pick ingredients & actions to keep 3. Build: new Builder with filtered JSON 4. Transfer: .add_resource for kept binaries 5. Sign: builder.sign()"]
+    Q3 -->|Nothing| P3["New Builder alone (fresh manifest, no prior provenance)"]
+```
+
 ## How should I add ingredients?
 
 There are two ways: using `add_ingredient()` and injecting ingredient JSON via `with_definition()`.  The table below summarizes these options.
@@ -84,7 +80,6 @@ There are two ways: using `add_ingredient()` and injecting ingredient JSON via `
 | --- | --- | --- |
 | `add_ingredient(json, path)` | Reads the source (a signed asset, an unsigned file, or a `.c2pa` archive), extracts its manifest store automatically, generates a thumbnail | Adding an ingredient where the library should handle extraction. Works with ingredient catalog archives too: pass the archive path and the library extracts the manifest data |
 | Inject via `with_definition()` + `add_resource()` | Accepts the ingredient JSON and all binary resources provided manually | Reconstructing from a reader or merging from multiple readers, where the data has already been extracted |
-
 
 ## When to use archives
 
@@ -96,12 +91,11 @@ There are two distinct archive concepts:
     - Transmitting a `Builder` state across a network boundary
 
 - **Ingredient archives** contain the manifest store data (`.c2pa` binary) from ingredients that were added to a `Builder`. When a signed asset is added as an ingredient via `add_ingredient()`, the library extracts and stores its manifest store as `manifest_data` within the ingredient record. When the `Builder` is then serialized via `to_archive()`, these ingredient manifest stores are included. Use ingredient archives when:
-
     - Building an ingredients catalog for pick-and-choose workflows
     - Preserving provenance history from source assets
     - Transferring ingredient data between `Reader` and `Builder`
 
-See also [Working stores](https://opensource.contentauthenticity.org/docs/rust-sdk/docs/working-stores).
+See also [Working stores](working-stores.md).
 
 Key consideration for builder archives: `from_archive()` creates a new `Builder` with **default** context settings. If specific settings are needed (e.g., thumbnails disabled), use `with_archive()` on a `Builder` that already has the desired context:
 
@@ -118,4 +112,4 @@ builder.sign(source, output, signer);
 
 ## What happens to the provenance chain when rebuilding a working store?
 
-When creating a new manifest, the chain is preserved once the original asset is added as an ingredient. The ingredient carries the original's manifest data, so validators can trace the full history. If the original is not added as an ingredient, the provenance chain is broken: the new manifest has no link to the original. This might be intentional (starting fresh) or a mistake (losing provenance).
+When creating a new manifest, the chain is preserved once the original asset is added as an ingredient. The ingredient carries the original asset's manifest data, so validators can trace the full history. If the original is not added as an ingredient, the provenance chain is broken: the new manifest has no link to the original. This might be intentional (starting fresh) or a mistake (losing provenance).

--- a/docs/intents.md
+++ b/docs/intents.md
@@ -47,12 +47,12 @@ Both of these code snippets produce the same signed manifest. But with intents, 
 
 ## Setting the intent
 
-YOu can set the intent on a `Builder` instance by:
+You can set the intent on a `Builder` instance by:
 
 - [Using Context](#using-context)
 - [Using `set_intent` on the `Builder`](#using-set_intent-on-builder)
 
-Don't set intent using the a deprecated `load_settings()` function. For existing code, see [Context and Settings - Migrating from deprecated APIs](context-settings.md#migrating-from-deprecated-apis).
+Don't set intent using the deprecated `load_settings()` function. For existing code, see [Context and Settings - Migrating from deprecated APIs](context-settings.md#migrating-from-deprecated-apis).
 
 ### Using Context
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -83,7 +83,7 @@ For full details see [Configuring the SDK with Context and Settings](context-set
 
 ### Creating a Context
 
-The `Context` class manages C2PA SDK configuration. There are two ways to create a context: direct construction and the ContextBuilder.
+The `Context` class manages C2PA SDK configuration. There are two ways to create a context: direct construction and using `ContextBuilder`.
 
 #### Direct construction
 
@@ -106,26 +106,9 @@ c2pa::Context context(R"({
 })");
 ```
 
-#### ContextBuilder
-
-The builder pattern is useful when you need to layer multiple configuration sources:
-
-```cpp
-c2pa::Settings settings;
-settings.set("builder.thumbnail.enabled", "true");
-
-auto context = c2pa::Context::ContextBuilder()
-    .with_settings(settings)
-    .with_json(R"({"verify": {"verify_after_sign": true}})")
-    .create_context();
-```
-
-> [!NOTE]
-> The ContextBuilder is consumed after calling `create_context()`. For single-source configuration, prefer direct construction.
-
 #### Using a Context
 
-Contexts are passed by reference to Builder and Reader constructors. The context is used only at construction; the implementation copies context state into the reader/builder, so the context does not need to outlive them.
+Contexts are passed by reference to `Builder` and `Reader` constructors. The context is used only at construction; the implementation copies context state into the reader/builder, so the context does not need to outlive them.
 
 ```cpp
 c2pa::Context context;
@@ -156,10 +139,9 @@ For example:
 
 ## Creating a Signer
 
-For testing you can create a signer using any supported algorithm by a Signer constructor. For the list of supported signing algorithms, see [Creating and using an X.509 certificate](https://opensource.contentauthenticity.org/docs/c2patool/x_509).
+For testing, you can create a signer using any supported algorithm by a `Signer` constructor. For the list of supported signing algorithms, see [Creating and using an X.509 certificate](https://opensource.contentauthenticity.org/docs/c2patool/x_509).
 
-There are multiple forms of constructors. But in this example we show how to create a signer with
-a public and private key.
+There are multiple constructor forms; this example shows how to create a signer with a public/private key pair.
 
 ```cpp
   Signer signer = Signer("<SIGNING_ALG>", "<PUBLIC_CERTS>",  "<PRIVATE_KEY>", "<TIMESTAMP_URL>");
@@ -177,7 +159,8 @@ For example:
 Signer signer = c2pa::Signer("Es256", certs, private_key, "http://timestamp.digicert.com");
 ```
 
-**WARNING**: Do not access a private key and certificate directly like this in production  because it's not secure. Instead use a hardware security module (HSM) and optionally a Key Management Service (KMS) to access the key; for example as show in the [C2PA Python Example](https://github.com/contentauth/c2pa-python-example).
+> [!WARNING]
+> Do not access a private key and certificate directly like this in production  because it's not secure. Instead use a hardware security module (HSM) and optionally a Key Management Service (KMS) to access the key; for example as shown in the [C2PA Python Example](https://github.com/contentauth/c2pa-python-example).
 
 ## Signing and embedding a manifest
 
@@ -207,9 +190,9 @@ The C++ library can validate [CAWG identity assertions](https://cawg.io/identity
 C2PA maintains two [trust lists](https://opensource.contentauthenticity.org/docs/conformance/trust-lists/)
 to verify the authenticity and integrity of Content Credentials attached to digital media: the C2PA trust list and the C2PA time-stamping authority (TSA) trust list. The C2PA trust list is a list of X.509 certificate trust anchors (either root or subordinate certification authorities) that issue certificates to conforming generator products under the C2PA Certificate Policy. The C2PA time-stamping authority (TSA) trust list is a list of X.509 certificate trust anchors (either root or subordinate certification authorities) that issue time-stamp signing certificates to TSAs.
 
-These trust lists need to be configured (loaded as settings) when using the SDK, using the Settings in the Context APIs. Using the Context API ensure proper propagation of settings (and trust) to Builder and Reader objects.
+Configure trust lists using the `Settings` and `Context` APIs. Using the `Context` API ensures proper propagation of settings (and trust) to `Builder` and `Reader` objects.
 
-Trust has an impact on manifest validation status, as a manifest for which a trust chain could be verified will be flagged as `Trusted`.
+Trust affects manifest validation status: a manifest whose trust chain was verified will be flagged as `Trusted`.
 
 ## More examples
 

--- a/docs/working-stores.md
+++ b/docs/working-stores.md
@@ -85,8 +85,9 @@ Use the `Reader` class to read manifest stores from signed assets.
 
 int main() {
     try {
+        c2pa::Context context;
         // Create a Reader from a signed asset file
-        auto reader = c2pa::Reader("signed_image.jpg");
+        auto reader = c2pa::Reader(context, "signed_image.jpg");
 
         // Get the manifest store as JSON
         std::string manifest_store_json = reader.json();
@@ -101,10 +102,10 @@ int main() {
 ```cpp
 #include <fstream>
 
+c2pa::Context context;
 std::ifstream file_stream("signed_image.jpg", std::ios::binary);
 if (file_stream.is_open()) {
-    // Create Reader from stream with MIME type
-    auto reader = c2pa::Reader("image/jpeg", file_stream);
+    auto reader = c2pa::Reader(context, "image/jpeg", file_stream);
     std::string manifest_json = reader.json();
     file_stream.close();
 }
@@ -218,19 +219,19 @@ std::string manifest_store_json = reader.json();  // This is the manifest store
 ### Creating a Builder (working store)
 
 ```cpp
-// Create with default context
-// manifest_json contains the starting manifest definition
-auto builder = c2pa::Builder(manifest_json);
+// Create with default settings
+c2pa::Context context;
+auto builder = c2pa::Builder(context, manifest_json);
 
-// Or with custom context
-c2pa::Context context(R"({
+// Or with custom settings
+c2pa::Context custom_context(R"({
   "builder": {
     "thumbnail": {
       "enabled": true
     }
   }
 })");
-auto builder = c2pa::Builder(context, manifest_json);
+auto builder = c2pa::Builder(custom_context, manifest_json);
 ```
 
 ### Creating a Signer
@@ -261,7 +262,8 @@ auto signer = c2pa::Signer(
 );
 ```
 
-**WARNING**: Never hard-code or directly access private keys in production. Use a Hardware Security Module (HSM) or Key Management Service (KMS).
+> [!WARNING]
+> Never hard-code or directly access private keys in production. Instead use a Hardware Security Module (HSM) or Key Management Service (KMS).
 
 Supported algorithms: Es256, Es384, Es512, Ps256, Ps384, Ps512, Ed25519. See [X.509 certificate documentation](https://opensource.contentauthenticity.org/docs/c2patool/x_509) for details.
 
@@ -339,7 +341,8 @@ int main() {
                                    "http://timestamp.digicert.com");
 
         // 4. Create working store (Builder) and sign
-        auto builder = c2pa::Builder(manifest_json);
+        c2pa::Context context;
+        auto builder = c2pa::Builder(context, manifest_json);
         builder.sign("source.jpg", "signed.jpg", signer);
 
         std::cout << "Asset signed - working store is now a manifest store" << std::endl;
@@ -419,7 +422,8 @@ When building a manifest, you add resources using identifiers. The SDK will refe
 **Pattern:**
 
 ```cpp
-auto builder = c2pa::Builder(manifest_json);
+c2pa::Context context;
+auto builder = c2pa::Builder(context, manifest_json);
 
 // Add resource with a simple identifier
 // The identifier must match what you reference in your manifest JSON
@@ -445,7 +449,8 @@ An ingredient archive is a serialized `Builder` with _exactly one_ ingredient.  
 When creating a manifest, add ingredients to preserve the provenance chain:
 
 ```cpp
-auto builder = c2pa::Builder(manifest_json);
+c2pa::Context context;
+auto builder = c2pa::Builder(context, manifest_json);
 
 // Define ingredient metadata
 const std::string ingredient_json = R"({
@@ -495,7 +500,7 @@ builder.add_ingredient(ingredient_json, "base_layer.png");
 
 ## Working with archives 
 
-A *archive* (C2PA archive) is a serialized working store (`Builder` object) saved to a file or stream.
+An *archive* (C2PA archive) is a serialized working store (`Builder` object) saved to a file or stream.
 
 Using archives provides these advantages:
 
@@ -585,7 +590,8 @@ void prepare_manifest() {
       "assertions": [ ... ]
     })";
 
-    auto builder = c2pa::Builder(manifest_json);
+    c2pa::Context context;
+    auto builder = c2pa::Builder(context, manifest_json);
     builder.add_resource("thumbnail", "thumb.jpg");
     builder.add_ingredient("{\"title\": \"Sketch\"}", "sketch.png");
 
@@ -635,7 +641,8 @@ assert(reader.is_embedded() == true);  // Manifest store is embedded
 Prevent embedding the manifest store in the asset:
 
 ```cpp
-auto builder = c2pa::Builder(manifest_json);
+c2pa::Context context;
+auto builder = c2pa::Builder(context, manifest_json);
 builder.set_no_embed();  // Don't embed the manifest store
 
 // Sign: manifest store is NOT embedded, manifest bytes are returned


### PR DESCRIPTION
Mostly clean up and copy edits, EXCEPT for changing the examples in `working-stores.md` to use Context when creating Builder.

@tmathern Please reivew/approve the changes to example code in https://github.com/contentauth/c2pa-c/pull/184/changes#diff-17022c84205513e9cecbaa2f78e7917a517ce2ca2b962e9ec381860a47d99c45