### PR TITLE
fix: Bump c2pa-rs version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,10 +14,10 @@
 cmake_minimum_required(VERSION 3.27)
 
 # This is the current version of this C++ project
-project(c2pa-c VERSION 0.20.1)
+project(c2pa-c VERSION 0.21.0)
 
 # Set the version of the c2pa_rs library used
-set(C2PA_VERSION "0.78.7")
+set(C2PA_VERSION "0.78.8")
 
 set(CMAKE_POLICY_DEFAULT_CMP0135 NEW)
 set(CMAKE_C_STANDARD 17)


### PR DESCRIPTION
Bump to v0.78.8, https://github.com/contentauth/c2pa-rs/releases/tag/c2pa-v0.78.8.
Enables JPEG XL support.