### PR TITLE
fix: Build with deprecations

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -239,7 +239,10 @@ if(MSVC)
         /sdl
         /guard:cf
         /GS
-        /DYNAMICBASE)
+        /DYNAMICBASE
+        # c2pa_cpp wraps the deprecated C API surface; silence C4996 so the
+        # wrapper still builds cleanly while end users still see the warning.
+        /wd4996)
 
     target_link_options(c2pa_cpp PRIVATE
         /DYNAMICBASE
@@ -254,6 +257,10 @@ else()
         -Wstack-protector
         -fstack-protector-strong
         -fPIC
+        # c2pa_cpp wraps the deprecated C API surface; silence the warning
+        # here so the wrapper still builds with -Werror while end users still
+        # see the deprecation warning when they call the C functions directly.
+        -Wno-deprecated-declarations
     )
 
     if(APPLE)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -240,7 +240,7 @@ if(MSVC)
         /guard:cf
         /GS
         /DYNAMICBASE
-        # c2pa_cpp wraps the deprecated C API surface; silence C4996 so the
+        # c2pa_cpp wraps the deprecated C API surface, silence C4996 so the
         # wrapper still builds cleanly while end users still see the warning.
         /wd4996)
 
@@ -257,9 +257,9 @@ else()
         -Wstack-protector
         -fstack-protector-strong
         -fPIC
-        # c2pa_cpp wraps the deprecated C API surface; silence the warning
+        # c2pa_cpp wraps the deprecated C API surface, silence the warning
         # here so the wrapper still builds with -Werror while end users still
-        # see the deprecation warning when they call the C functions directly.
+        # see the deprecation warning.
         -Wno-deprecated-declarations
     )
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -182,6 +182,10 @@ if(WIN32)
 else()
     # On Unix systems, link directly to the shared library
     target_link_libraries(ctest PRIVATE "${C2PA_C_LIB}")
+    # c-app-test deliberately exercises the deprecated C API so we can keep
+    # testing it; silence the resulting -Wdeprecated-declarations so -Werror
+    # does not fail the build.
+    target_compile_options(ctest PRIVATE -Wno-deprecated-declarations)
 endif()
 target_include_directories(ctest PRIVATE
     "${C2PA_PREBUILT_INCLUDE_DIR}"

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -183,8 +183,8 @@ else()
     # On Unix systems, link directly to the shared library
     target_link_libraries(ctest PRIVATE "${C2PA_C_LIB}")
     # c-app-test deliberately exercises the deprecated C API so we can keep
-    # testing it; silence the resulting -Wdeprecated-declarations so -Werror
-    # does not fail the build.
+    # testing it. Silences the resulting -Wdeprecated-declarations so -Werror
+    # does not fail the (test) build.
     target_compile_options(ctest PRIVATE -Wno-deprecated-declarations)
 endif()
 target_include_directories(ctest PRIVATE


### PR DESCRIPTION
c2pa-rs deprecated a bunch of things in https://github.com/contentauth/c2pa-rs/pull/2032. 
We still want to build and run tests to exercise the deprecated APIs, until they are gone for good.

CI/CD build will only check the new builds once https://github.com/contentauth/c2pa-rs/pull/2032 is merged, released, and the released version picked up by CI/CD.