### PR TITLE
ci: add c2pa-rs breaking-change receiver workflow

### DIFF
--- a/.github/workflows/test-c2pa-rs-branch.yml
+++ b/.github/workflows/test-c2pa-rs-branch.yml
@@ -1,0 +1,82 @@
+# Receiver for c2pa-cpp. Install as
+# .github/workflows/test-c2pa-rs-branch.yml in contentauth/c2pa-cpp.
+#
+# c2pa-cpp normally downloads prebuilt native libs from c2pa-rs releases via
+# CMake FetchContent, but its CMakeLists supports a build-from-source path:
+# setting C2PA_BUILD_FROM_SOURCE=ON and C2PA_RS_PATH=<c2pa-rs checkout> builds
+# c2pa_c_ffi locally with cargo. So we re-target by checking out c2pa-rs at the
+# PR branch and building against it. There is no committable diff, so this
+# receiver is STATUS-ONLY (no draft PR); the status links to this workflow run.
+#
+# Requires the CROSS_ORG_PR_TOKEN secret (see contentauth/c2pa-rs
+# docs/breaking-change-automation/README.md).
+
+name: Test against c2pa-rs branch
+
+on:
+  repository_dispatch:
+    types: [c2pa-rs-breaking-change]
+
+permissions:
+  contents: read
+
+env:
+  REPO_NAME: c2pa-cpp
+  C2PA_RS_PR: ${{ github.event.client_payload.pr_number }}
+  C2PA_RS_REF: ${{ github.event.client_payload.ref }}
+  C2PA_RS_SHA: ${{ github.event.client_payload.head_sha }}
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout c2pa-cpp
+        uses: actions/checkout@v6
+
+      - name: Checkout c2pa-rs @ PR branch
+        uses: actions/checkout@v6
+        with:
+          repository: contentauth/c2pa-rs
+          ref: ${{ github.event.client_payload.ref }}
+          path: c2pa-rs
+
+      - name: Report start to c2pa-rs
+        env:
+          GH_TOKEN: ${{ secrets.CROSS_ORG_PR_TOKEN }}
+        run: |
+          gh api -X POST "repos/contentauth/c2pa-rs/statuses/$C2PA_RS_SHA" \
+            -f state=pending \
+            -f "context=breaking-changes / $REPO_NAME" \
+            -f "description=Building $REPO_NAME against c2pa-rs branch $C2PA_RS_REF..." >/dev/null
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Install build tools
+        run: sudo apt-get update && sudo apt-get install -y ninja-build cmake
+
+      - name: Build against local c2pa-rs and test
+        id: build
+        continue-on-error: true
+        env:
+          C2PA_BUILD_FROM_SOURCE: "ON"
+          C2PA_RS_PATH: ${{ github.workspace }}/c2pa-rs
+        run: make test
+
+      - name: Report result to c2pa-rs
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.CROSS_ORG_PR_TOKEN }}
+        run: |
+          run_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          if [ "${{ steps.build.outcome }}" = "success" ]; then
+            state=success
+            desc="$REPO_NAME builds against the c2pa-rs branch."
+          else
+            state=failure
+            desc="$REPO_NAME does NOT build against the c2pa-rs branch — changes needed."
+          fi
+          gh api -X POST "repos/contentauth/c2pa-rs/statuses/$C2PA_RS_SHA" \
+            -f "state=$state" \
+            -f "context=breaking-changes / $REPO_NAME" \
+            -f "description=$desc" \
+            -f "target_url=$run_url" >/dev/null

--- a/.github/workflows/test-c2pa-rs-branch.yml
+++ b/.github/workflows/test-c2pa-rs-branch.yml
@@ -30,10 +30,14 @@ jobs:
   verify:
     runs-on: ubuntu-latest
     steps:
+      # c2pa-cpp's build-from-source expects c2pa-rs as a filesystem neighbor,
+      # so check both out as siblings under the workspace.
       - name: Checkout c2pa-cpp
         uses: actions/checkout@v6
+        with:
+          path: c2pa-cpp
 
-      - name: Checkout c2pa-rs @ PR branch
+      - name: Checkout c2pa-rs @ PR branch (sibling of c2pa-cpp)
         uses: actions/checkout@v6
         with:
           repository: contentauth/c2pa-rs
@@ -54,13 +58,19 @@ jobs:
       - name: Install build tools
         run: sudo apt-get update && sudo apt-get install -y ninja-build cmake
 
+      # Follows c2pa-cpp's documented "Building using local sources" flow
+      # (README): C2PA_BUILD_FROM_SOURCE + C2PA_RS_PATH, with LD_LIBRARY_PATH set
+      # so the tests can load the freshly built libc2pa_c at runtime.
       - name: Build against local c2pa-rs and test
         id: build
         continue-on-error: true
+        working-directory: c2pa-cpp
         env:
           C2PA_BUILD_FROM_SOURCE: "ON"
           C2PA_RS_PATH: ${{ github.workspace }}/c2pa-rs
-        run: make test
+        run: |
+          export LD_LIBRARY_PATH="$PWD/build/release/tests:${LD_LIBRARY_PATH:-}"
+          make test-release
 
       - name: Report result to c2pa-rs
         if: always()


### PR DESCRIPTION
Part of the contentauth/c2pa-rs `breaking-changes` automation (see c2pa-rs docs/breaking-change-automation/README.md).

When a c2pa-rs PR is labeled `breaking-changes`, it sends a `repository_dispatch` here; this workflow re-targets the build to the c2pa-rs PR branch, runs the build/tests, and reports a commit status back to the originating c2pa-rs PR.

Requires the org secret `CROSS_ORG_PR_TOKEN`.

Opened as a draft for review — do not merge until the token is wired up and the workflow has been sanity-checked.