### PR TITLE
DO NOT MERGE: Test build against c2pa-rs 0.90.0-rc.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,16 +31,39 @@ jobs:
       matrix:
         os: [windows-latest, windows-11-arm, macos-latest, macos-15-intel, ubuntu-latest, ubuntu-22.04, ubuntu-22.04-arm, ubuntu-24.04-arm]
 
+    # TEMPORARY: exercise the c2pa-rs 0.90.0-rc.1 release candidate before it
+    # ships as a release, to surface breaking build issues early. No prebuilt
+    # release binaries exist for the RC, so we build the c2pa_c FFI from source
+    # (C2PA_BUILD_FROM_SOURCE) against a pinned commit instead of downloading the
+    # C2PA_VERSION prebuilt from CMakeLists.txt. Revert this env block and the two
+    # "(TEMPORARY)" steps below once the RC ships and C2PA_VERSION can be bumped.
+    env:
+      C2PA_RS_REF: 66d20c655769b9a46fa87221a996ad5686e0c6f9  # HEAD of branch 0.90.0-rc.1
+      C2PA_BUILD_FROM_SOURCE: "1"
+      C2PA_RS_PATH: ${{ github.workspace }}/c2pa-rs
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Check out c2pa-rs release candidate (TEMPORARY)
+        uses: actions/checkout@v4
+        with:
+          repository: contentauth/c2pa-rs
+          ref: ${{ env.C2PA_RS_REF }}
+          path: c2pa-rs
+
+      - name: Install Rust toolchain (TEMPORARY - to build the c2pa-rs RC from source)
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Install Ninja (Cmake build generator)
         uses: seanmiddleditch/gha-setup-ninja@master
 
       - name: Setup MSVC toolchain on Windows
-        if: matrix.os == 'windows-latest'
+        if: runner.os == 'Windows'
         uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: ${{ matrix.os == 'windows-11-arm' && 'arm64' || 'amd64' }}
 
       - name: Print make version and path
         run: |


### PR DESCRIPTION
## Purpose (temporary / do not merge)

Exercise the **c2pa-rs `0.90.0-rc.1`** release candidate against this repo's build and test suite **before it ships as a real release**, so any breaking build/API/FFI issues surface early.

Pinned to commit `66d20c655769b9a46fa87221a996ad5686e0c6f9` (the HEAD of branch `0.90.0-rc.1`) for reproducibility.

## Why this is a CI-only change

The default build downloads **prebuilt release binaries** selected by `C2PA_VERSION` in `CMakeLists.txt`. There is **no `c2pa-v0.90.0-rc.1` release** (latest is `c2pa-v0.89.3`), so there are no prebuilt binaries to point at.

The only way to exercise the RC is the existing **build-from-source** path. So this PR changes `.github/workflows/ci.yml` to:

- Check out `contentauth/c2pa-rs` at the pinned commit into `c2pa-rs/`.
- Install the Rust toolchain.
- Build the `c2pa_c` FFI from source via `C2PA_BUILD_FROM_SOURCE=1` + `C2PA_RS_PATH`, instead of downloading the `C2PA_VERSION` prebuilt.
- Broaden the MSVC toolchain setup to all Windows runners (arch chosen per runner), since building Rust from source needs it.

Runs across the **full OS matrix** (Windows x64/arm64, macOS arm64/intel, Ubuntu x64/arm64). Note: source builds are officially "only tested on Linux," so non-Linux failures may reflect source-build toolchain integration rather than genuine RC breakage — read results with that in mind.

`CMakeLists.txt` is intentionally left untouched so the change is fully contained in the workflow and trivial to revert.

## Reverting

Once the RC ships as a release, revert the `env:` block and the two `(TEMPORARY)` steps in `.github/workflows/ci.yml`, then bump `C2PA_VERSION` in `CMakeLists.txt` normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)